### PR TITLE
Refactor interactive UI: remove gouroutines

### DIFF
--- a/cmd/unused/ui/interactive/model.go
+++ b/cmd/unused/ui/interactive/model.go
@@ -137,7 +137,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.output.SetContent(sb.String())
 
-		return m, tea.Batch(spinner.Tick, deleteCurrent(msg))
+		return m, deleteCurrent(msg)
 
 	case spinner.TickMsg:
 		var cmd tea.Cmd


### PR DESCRIPTION
This PR removes all weird usage of goroutines with its synchronization to instead use [`tea.Cmd`](https://github.com/charmbracelet/bubbletea/blob/v0.21.0/tea.go#L56). By using a standard interface to send and receive messages we make the code easier to read and reason about.

In addition to this it also removes now obsolete code, and opens up the potential to add some testing in the future.