### PR TITLE
Add '-group-by' flag to compute aggregated disk usage

### DIFF
--- a/cmd/unused/internal/ui/group_table.go
+++ b/cmd/unused/internal/ui/group_table.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/grafana/unused"
+)
+
+func GroupTable(ctx context.Context, options Options) error {
+	disks, err := listUnusedDisks(ctx, options.Providers)
+	if err != nil {
+		return err
+	}
+
+	if options.Filter.Key != "" {
+		filtered := make(unused.Disks, 0, len(disks))
+		for _, d := range disks {
+			if d.Meta().Matches(options.Filter.Key, options.Filter.Value) {
+				filtered = append(filtered, d)
+			}
+		}
+		disks = filtered
+	}
+
+	if len(disks) == 0 {
+		fmt.Println("No disks found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 8, 4, 2, ' ', 0)
+
+	headers := []string{"PROVIDER", "GROUP_BY", "TYPE", "SIZE_GB"}
+	aggrData := make(map[[3]string]int)
+
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+
+	var aggrValue string
+	for _, d := range disks {
+		p := d.Provider()
+		if value, ok := d.Meta()[options.Group]; ok {
+			aggrValue = value
+		} else {
+			aggrValue = "NONE"
+		}
+		aggrKey := [3]string{p.Name(), aggrValue, string(d.DiskType())}
+		aggrData[aggrKey] += d.SizeGB()
+	}
+
+	for info, totalSize := range aggrData {
+		row := info[:]
+		row = append(row, fmt.Sprintf("%d", totalSize))
+		fmt.Fprintln(w, strings.Join(row, "\t"))
+	}
+
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("flushing table contents: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/unused/internal/ui/ui.go
+++ b/cmd/unused/internal/ui/ui.go
@@ -14,6 +14,7 @@ type Options struct {
 	Providers    []unused.Provider
 	ExtraColumns []string
 	Filter       Filter
+	Group        string
 	Verbose      bool
 }
 

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -61,6 +61,8 @@ func main() {
 		return nil
 	})
 
+	flag.StringVar(&options.Group, "group-by", "", "Group by disk metadata values")
+
 	flag.Parse()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
@@ -78,6 +80,9 @@ func main() {
 	options.Providers = providers
 
 	var display ui.DisplayFunc = ui.Table
+	if options.Group != "" {
+		display = ui.GroupTable
+	}
 	if interactiveMode {
 		display = ui.Interactive
 	}


### PR DESCRIPTION
Draft on how "Group by" functionality could be added.

Example output:
```
> unused -gcp.project dev-project -group-by kubernetes.io/created-for/pvc/namespace
PROVIDER  GROUP_BY                         TYPE    SIZE_GB
GCP       agent-smoke-test                 ssd     30
GCP       default                          hdd     941
GCP       preview                          ssd     120
GCP       NONE                             ssd     1000
GCP       ge-logs                          hdd     5
...

> unused -gcp.project dev-project -group-by zone
PROVIDER  GROUP_BY       TYPE    SIZE_GB
GCP       us-central1-a  ssd     56370
GCP       us-central1-a  hdd     4340
GCP       us-central1-b  ssd     10528
GCP       us-central1-f  ssd     6188
GCP       us-central1-f  hdd     451
GCP       us-central1-b  hdd     1150
```