### PR TITLE
Add csv_export command

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -21,6 +21,9 @@ type Provider struct {
 // Name returns AWS.
 func (p *Provider) Name() string { return "AWS" }
 
+// Project returns profile name for AWS.
+func (p *Provider) Account() string { return p.meta["profile"]}
+
 // Meta returns the provider metadata.
 func (p *Provider) Meta() unused.Meta { return p.meta }
 

--- a/azure/provider.go
+++ b/azure/provider.go
@@ -22,6 +22,9 @@ type Provider struct {
 // Name returns Azure.
 func (p *Provider) Name() string { return "Azure" }
 
+// Project returns subscription name for Azure.
+func (p *Provider) Account() string { return p.meta["subscription"]}
+
 // Meta returns the provider metadata.
 func (p *Provider) Meta() unused.Meta { return p.meta }
 

--- a/cmd/unused/internal/ui/csv_export.go
+++ b/cmd/unused/internal/ui/csv_export.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/grafana/unused"
+	"github.com/grafana/unused/cmd/internal"
+)
+
+func CsvExport(ctx context.Context, options Options) error {
+	disks, err := listUnusedDisks(ctx, options.Providers)
+	if err != nil {
+		return err
+	}
+
+	if options.Filter.Key != "" {
+		filtered := make(unused.Disks, 0, len(disks))
+		for _, d := range disks {
+			if d.Meta().Matches(options.Filter.Key, options.Filter.Value) {
+				filtered = append(filtered, d)
+			}
+		}
+		disks = filtered
+	}
+
+	if len(disks) == 0 {
+		return nil
+	}
+
+	w := csv.NewWriter(os.Stdout)
+	defer w.Flush()
+
+	headers := []string{"PROVIDER", "ACCOUNT", "DISK", "AGE", "UNUSED", "TYPE", "SIZE_GB"}
+	if options.RawDate {
+		headers[3] = "CREATED"
+	}
+	for _, c := range options.ExtraColumns {
+		headers = append(headers, "META:"+c)
+	}
+	if options.Verbose {
+		headers = append(headers, "PROVIDER_META", "DISK_META")
+	}
+
+	w.Write(headers)
+
+	for _, d := range disks {
+		p := d.Provider()
+
+		row := []string{p.Name(), p.Account(), d.Name(), internal.Age(d.CreatedAt()), internal.Age(d.LastUsedAt()), string(d.DiskType()), fmt.Sprintf("%d", d.SizeGB())}
+		if options.RawDate {
+			row[3] = d.CreatedAt().Format(time.RFC3339)
+			row[4] = d.LastUsedAt().Format(time.RFC3339)
+		}
+		meta := d.Meta()
+		for _, c := range options.ExtraColumns {
+			row = append(row, meta[c])
+		}
+		if options.Verbose {
+			row = append(row, p.Meta().String(), d.Meta().String())
+		}
+
+		w.Write(row)
+	}
+
+	return nil
+}

--- a/cmd/unused/internal/ui/table.go
+++ b/cmd/unused/internal/ui/table.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"text/tabwriter"
+	"time"
 
 	"github.com/grafana/unused"
 	"github.com/grafana/unused/cmd/internal"
@@ -36,6 +37,9 @@ func Table(ctx context.Context, options Options) error {
 	w := tabwriter.NewWriter(os.Stdout, 8, 4, 2, ' ', 0)
 
 	headers := []string{"PROVIDER", "DISK", "AGE", "UNUSED", "TYPE", "SIZE_GB"}
+	if options.RawDate {
+		headers[2] = "CREATED"
+	}
 	for _, c := range options.ExtraColumns {
 		headers = append(headers, "META:"+c)
 	}
@@ -49,6 +53,10 @@ func Table(ctx context.Context, options Options) error {
 		p := d.Provider()
 
 		row := []string{p.Name(), d.Name(), internal.Age(d.CreatedAt()), internal.Age(d.LastUsedAt()), string(d.DiskType()), fmt.Sprintf("%d", d.SizeGB())}
+		if options.RawDate {
+			row[2] = d.CreatedAt().Format(time.RFC3339)
+			row[3] = d.LastUsedAt().Format(time.RFC3339)
+		}
 		meta := d.Meta()
 		for _, c := range options.ExtraColumns {
 			row = append(row, meta[c])

--- a/cmd/unused/internal/ui/ui.go
+++ b/cmd/unused/internal/ui/ui.go
@@ -15,6 +15,8 @@ type Options struct {
 	ExtraColumns []string
 	Filter       Filter
 	Group        string
+	RawDate      bool
+	ExportCSV    bool
 	Verbose      bool
 }
 

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -62,6 +62,9 @@ func main() {
 	})
 
 	flag.StringVar(&options.Group, "group-by", "", "Group by disk metadata values")
+	flag.BoolVar(&options.ExportCSV, "export-csv", false, "Export in CSV format")
+
+	flag.BoolVar(&options.RawDate, "raw-date", false, "Show dates for created and last_used fields")
 
 	flag.Parse()
 
@@ -82,6 +85,9 @@ func main() {
 	var display ui.DisplayFunc = ui.Table
 	if options.Group != "" {
 		display = ui.GroupTable
+	}
+	if options.ExportCSV {
+		display = ui.CsvExport
 	}
 	if interactiveMode {
 		display = ui.Interactive

--- a/disk.go
+++ b/disk.go
@@ -36,5 +36,6 @@ type DiskType string
 const (
 	SSD     DiskType = "ssd"
 	HDD     DiskType = "hdd"
+	BALANCED DiskType = "balanced"
 	Unknown DiskType = "unknown"
 )

--- a/gcp/disk.go
+++ b/gcp/disk.go
@@ -60,6 +60,8 @@ func (d *Disk) DiskType() unused.DiskType {
 		return unused.SSD
 	case "pd-standard":
 		return unused.HDD
+	case "pd-balanced":
+		return unused.BALANCED
 	default:
 		return unused.Unknown
 	}

--- a/gcp/provider.go
+++ b/gcp/provider.go
@@ -29,6 +29,9 @@ type Provider struct {
 // Name returns GCP.
 func (p *Provider) Name() string { return "GCP" }
 
+// Project returns project name for GCP.
+func (p *Provider) Account() string { return p.meta["project"]}
+
 // Meta returns the provider metadata.
 func (p *Provider) Meta() unused.Meta { return p.meta }
 

--- a/provider.go
+++ b/provider.go
@@ -7,6 +7,9 @@ type Provider interface {
 	// Name returns the provider name.
 	Name() string
 
+	// Project returns project name for GCP, profile name for AWS and subscription name for Azure
+	Account() string
+
 	// ListUnusedDisks returns a list of unused disks for the given
 	// provider.
 	ListUnusedDisks(ctx context.Context) (Disks, error)

--- a/unusedtest/provider.go
+++ b/unusedtest/provider.go
@@ -30,6 +30,19 @@ func (p *Provider) Name() string { return p.name }
 
 func (p *Provider) Meta() unused.Meta { return p.meta }
 
+func (p *Provider) Account() string {
+	switch p.name {
+	case "GCP":
+		return p.meta["project"]
+	case "AWS":
+		return p.meta["profile"]
+	case "Azure":
+		return p.meta["subscription"]
+	default:
+		return ""
+	}
+}
+
 func (p *Provider) SetMeta(meta unused.Meta) { p.meta = meta }
 
 func (p *Provider) ListUnusedDisks(ctx context.Context) (unused.Disks, error) {


### PR DESCRIPTION
Closes: https://github.com/grafana/unused/issues/51

This is proof-of-concept solution to actually test that idea. I added here `csv_export` as separate `ui` as I don't found yet how to make it with nice and clear code: switch between `csv` and `tabWriter` in `Table` functions.

Lets discuss is it a good idea or not, should we keep it as separate `ui` or restructure a bit. @inkel what do you think?