### PR TITLE
Make help colors brighter

### DIFF
--- a/cmd/unused/internal/ui/interactive/model.go
+++ b/cmd/unused/internal/ui/interactive/model.go
@@ -49,7 +49,7 @@ func New(providers []unused.Provider, extraColumns []string, key, value string) 
 		extraCols:    extraColumns,
 		key:          key,
 		value:        value,
-		help:         help.New(),
+		help:         newHelp(),
 	}
 }
 
@@ -258,4 +258,34 @@ func deleteCurrent(p deleteProgress) tea.Cmd {
 	}
 
 	return func() tea.Msg { return p }
+}
+
+func newHelp() help.Model {
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
+		Light: "#909090",
+		Dark:  "#AAAAAA",
+	})
+
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
+		Light: "#B2B2B2",
+		Dark:  "#999999",
+	})
+
+	sepStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
+		Light: "#DDDADA",
+		Dark:  "#3C3C3C",
+	})
+
+	m := help.New()
+	m.Styles = help.Styles{
+		ShortKey:       keyStyle,
+		ShortDesc:      descStyle,
+		ShortSeparator: sepStyle,
+		Ellipsis:       sepStyle.Copy(),
+		FullKey:        keyStyle.Copy(),
+		FullDesc:       descStyle.Copy(),
+		FullSeparator:  sepStyle.Copy(),
+	}
+
+	return m
 }


### PR DESCRIPTION
Change the dark version of the bottom help bar colors to a brighter schema so they look better on dark backgrounds. On my machine they look like this:

<img width="990" alt="Screenshot 2023-09-12 at 11 32 25" src="https://github.com/grafana/unused/assets/108421/5ca1954a-612e-4d05-a46e-08c02cb028e0">

Closes #55.