### PR TITLE
Enable dry-run mode

### DIFF
--- a/cmd/unused/internal/ui/interactive.go
+++ b/cmd/unused/internal/ui/interactive.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Interactive(ctx context.Context, options Options) error {
-	m := interactive.New(options.Providers, options.ExtraColumns, options.Filter.Key, options.Filter.Value)
+	m := interactive.New(options.Providers, options.ExtraColumns, options.Filter.Key, options.Filter.Value, options.DryRun)
 
 	if err := tea.NewProgram(m).Start(); err != nil {
 		return fmt.Errorf("cannot start interactive UI: %w", err)

--- a/cmd/unused/internal/ui/interactive/model.go
+++ b/cmd/unused/internal/ui/interactive/model.go
@@ -37,11 +37,11 @@ type Model struct {
 	err          error
 }
 
-func New(providers []unused.Provider, extraColumns []string, key, value string) Model {
+func New(providers []unused.Provider, extraColumns []string, key, value string, dryRun bool) Model {
 	m := Model{
 		providerList: newProviderListModel(providers),
 		providerView: newProviderViewModel(extraColumns),
-		deleteView:   newDeleteViewModel(),
+		deleteView:   newDeleteViewModel(dryRun),
 		disks:        make(map[unused.Provider]unused.Disks),
 		state:        stateProviderList,
 		spinner:      spinner.New(),

--- a/cmd/unused/internal/ui/ui.go
+++ b/cmd/unused/internal/ui/ui.go
@@ -16,6 +16,7 @@ type Options struct {
 	Filter       Filter
 	Group        string
 	Verbose      bool
+	DryRun       bool
 }
 
 type DisplayFunc func(ctx context.Context, options Options) error

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -39,6 +39,7 @@ func main() {
 
 	flag.BoolVar(&interactiveMode, "i", false, "Interactive UI mode")
 	flag.BoolVar(&options.Verbose, "v", false, "Verbose mode")
+	flag.BoolVar(&options.DryRun, "n", false, "Do not delete disks in interactive mode")
 
 	flag.Func("filter", "Filter by disk metadata", func(v string) error {
 		ps := strings.SplitN(v, "=", 2)


### PR DESCRIPTION
This partially addresses #57 by adding a `-dry-run` flag that will enable viewing the whole interactive UI workflow up until the confirmation step in the delete view, telling the user about dry-run being enabled and thus that nothing will be deleted.

<img width="589" alt="Screenshot 2023-09-27 at 14 53 51" src="https://github.com/grafana/unused/assets/108421/d16b3ea6-0f53-4ef4-b774-830f9eac827c">
