### PR TITLE
Replace `inkel/logfmt` with `slog`

### DIFF
--- a/cmd/internal/providers.go
+++ b/cmd/internal/providers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 
 	azcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
@@ -14,13 +15,12 @@ import (
 	"github.com/grafana/unused/aws"
 	"github.com/grafana/unused/azure"
 	"github.com/grafana/unused/gcp"
-	"github.com/inkel/logfmt"
 	"google.golang.org/api/compute/v1"
 )
 
 var ErrNoProviders = errors.New("please select at least one provider")
 
-func CreateProviders(ctx context.Context, logger *logfmt.Logger, gcpProjects, awsProfiles, azureSubs []string) ([]unused.Provider, error) {
+func CreateProviders(ctx context.Context, logger *slog.Logger, gcpProjects, awsProfiles, azureSubs []string) ([]unused.Provider, error) {
 	providers := make([]unused.Provider, 0, len(gcpProjects)+len(awsProfiles)+len(azureSubs))
 
 	for _, projectID := range gcpProjects {

--- a/cmd/internal/providers_test.go
+++ b/cmd/internal/providers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -12,11 +13,10 @@ import (
 	"github.com/grafana/unused/azure"
 	"github.com/grafana/unused/cmd/internal"
 	"github.com/grafana/unused/gcp"
-	"github.com/inkel/logfmt"
 )
 
 func TestCreateProviders(t *testing.T) {
-	l := logfmt.NewLogger(io.Discard)
+	l := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	t.Run("fail when no provider is given", func(t *testing.T) {
 		ps, err := internal.CreateProviders(context.Background(), l, nil, nil, nil)

--- a/cmd/unused-exporter/config.go
+++ b/cmd/unused-exporter/config.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/grafana/unused/cmd/internal"
-	"github.com/inkel/logfmt"
 )
 
 type config struct {
@@ -24,5 +24,5 @@ type config struct {
 		Timeout time.Duration
 	}
 
-	Logger *logfmt.Logger
+	Logger *slog.Logger
 }

--- a/cmd/unused-exporter/main.go
+++ b/cmd/unused-exporter/main.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/grafana/unused/cmd/internal"
-	"github.com/inkel/logfmt"
 )
 
 func main() {
@@ -46,9 +45,7 @@ func main() {
 }
 
 func realMain(ctx context.Context, cfg config) error {
-	// TODO(inkel) pass cfg.Logger instead of old logfmt logger
-	logger := logfmt.NewLogger(os.Stdout)
-	providers, err := internal.CreateProviders(ctx, logger, cfg.Providers.GCP, cfg.Providers.AWS, cfg.Providers.Azure)
+	providers, err := internal.CreateProviders(ctx, cfg.Logger, cfg.Providers.GCP, cfg.Providers.AWS, cfg.Providers.Azure)
 	if err != nil {
 		return err
 	}

--- a/cmd/unused-exporter/main.go
+++ b/cmd/unused-exporter/main.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"time"
@@ -22,7 +23,7 @@ import (
 
 func main() {
 	cfg := config{
-		Logger: logfmt.NewLogger(os.Stdout),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
 	internal.ProviderFlags(flag.CommandLine, &cfg.Providers.GCP, &cfg.Providers.AWS, &cfg.Providers.Azure)
@@ -45,7 +46,9 @@ func main() {
 }
 
 func realMain(ctx context.Context, cfg config) error {
-	providers, err := internal.CreateProviders(ctx, cfg.Logger, cfg.Providers.GCP, cfg.Providers.AWS, cfg.Providers.Azure)
+	// TODO(inkel) pass cfg.Logger instead of old logfmt logger
+	logger := logfmt.NewLogger(os.Stdout)
+	providers, err := internal.CreateProviders(ctx, logger, cfg.Providers.GCP, cfg.Providers.AWS, cfg.Providers.Azure)
 	if err != nil {
 		return err
 	}

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -17,13 +17,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
 
 	"github.com/grafana/unused/cmd/internal"
 	"github.com/grafana/unused/cmd/unused/internal/ui"
-	"github.com/inkel/logfmt"
 )
 
 func main() {
@@ -69,7 +69,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	logger := logfmt.NewLogger(os.Stderr)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 	providers, err := internal.CreateProviders(ctx, logger, gcpProjects, awsProfiles, azureSubs)
 	if err != nil {

--- a/gcp/provider.go
+++ b/gcp/provider.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/grafana/unused"
-	"github.com/inkel/logfmt"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -23,7 +23,7 @@ type Provider struct {
 	project string
 	svc     *compute.Service
 	meta    unused.Meta
-	logger  *logfmt.Logger
+	logger  *slog.Logger
 }
 
 // Name returns GCP.
@@ -37,7 +37,7 @@ func (p *Provider) Meta() unused.Meta { return p.meta }
 // A valid GCP compute service must be supplied in order to listed the
 // unused resources. It also requires a valid project ID which should
 // be the project where the disks were created.
-func NewProvider(logger *logfmt.Logger, svc *compute.Service, project string, meta unused.Meta) (*Provider, error) {
+func NewProvider(logger *slog.Logger, svc *compute.Service, project string, meta unused.Meta) (*Provider, error) {
 	if project == "" {
 		return nil, ErrMissingProject
 	}
@@ -69,11 +69,11 @@ func (p *Provider) ListUnusedDisks(ctx context.Context) (unused.Disks, error) {
 
 					m, err := diskMetadata(d)
 					if err != nil {
-						p.logger.Log("cannot parse disk metadata", logfmt.Labels{
-							"project": p.project,
-							"disk":    d.Name,
-							"err":     err,
-						})
+						p.logger.Error("cannot parse disk metadata",
+							slog.String("project", p.project),
+							slog.String("disk", d.Name),
+							slog.String("err", err.Error()),
+						)
 					}
 					disks = append(disks, &Disk{d, p, m})
 				}

--- a/gcp/provider_test.go
+++ b/gcp/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -14,13 +15,12 @@ import (
 	"github.com/grafana/unused"
 	"github.com/grafana/unused/gcp"
 	"github.com/grafana/unused/unusedtest"
-	"github.com/inkel/logfmt"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 )
 
 func TestNewProvider(t *testing.T) {
-	l := logfmt.NewLogger(io.Discard)
+	l := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	t.Run("project is required", func(t *testing.T) {
 		p, err := gcp.NewProvider(l, nil, "", nil)
@@ -48,7 +48,7 @@ func TestNewProvider(t *testing.T) {
 
 func TestProviderListUnusedDisks(t *testing.T) {
 	ctx := context.Background()
-	l := logfmt.NewLogger(io.Discard)
+	l := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// are we requesting the right API endpoint?
@@ -134,7 +134,7 @@ func TestProviderListUnusedDisks(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		l := logfmt.NewLogger(&buf)
+		l := slog.New(slog.NewTextHandler(&buf, nil))
 
 		p, err := gcp.NewProvider(l, svc, "my-project", nil)
 		if err != nil {
@@ -151,7 +151,7 @@ func TestProviderListUnusedDisks(t *testing.T) {
 		}
 
 		// check that we logged about it
-		m, _ := regexp.MatchString(`msg="cannot parse disk metadata".+disk="disk-2"`, buf.String())
+		m, _ := regexp.MatchString(`msg="cannot parse disk metadata".+disk=disk-2`, buf.String())
 		if !m {
 			t.Fatal("expecting a log line to be emitted")
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/charmbracelet/bubbletea v0.20.0
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/evertras/bubble-table v0.12.0
-	github.com/inkel/logfmt v0.0.2
 	github.com/prometheus/client_golang v1.12.1
 	google.golang.org/api v0.114.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/unused
 
-go 1.18
+go 1.21
 
 require (
 	github.com/Azure/azure-sdk-for-go v63.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,6 @@ github.com/googleapis/gax-go/v2 v2.7.1/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/inkel/logfmt v0.0.2 h1:d9KQM5A75CDBWY7+R3Tfoxlm5h1x+YqtzY4IT0yWBgo=
-github.com/inkel/logfmt v0.0.2/go.mod h1:GNgJsItqZADetq+vT9ssW2BWIRbGalkGaJKa1GBUYZ8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2Aawl
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/longrunning v0.4.1 h1:v+yFJOfKC3yZdY6ZUI933pIYdhyhV8S3NpWrXWmg7jM=
+cloud.google.com/go/longrunning v0.4.1/go.mod h1:4iWDqhBZ70CvZ6BfETbvam3T8FMvLK+eFj0E6AaRQTo=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -191,6 +192,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=


### PR DESCRIPTION
This PR replaces the logging library github.com/inkel/logfmt for the stdlib [`slog`](https://pkg.go.dev/log/slog) one, which is more tested and maintained.

This also makes the whole project depend on Go 1.21.