### PR TITLE
Updating Cache: QoL Improvments

### DIFF
--- a/aws/provider.go
+++ b/aws/provider.go
@@ -14,8 +14,9 @@ var _ unused.Provider = &Provider{}
 
 // Provider implements [unused.Provider] for AWS.
 type Provider struct {
-	client *ec2.Client
-	meta   unused.Meta
+	client  *ec2.Client
+	profile string
+	meta    unused.Meta
 }
 
 // Name returns AWS.
@@ -24,19 +25,23 @@ func (p *Provider) Name() string { return "AWS" }
 // Meta returns the provider metadata.
 func (p *Provider) Meta() unused.Meta { return p.meta }
 
+// Id returns the profile of this provider.
+func (p *Provider) Id() string { return p.profile }
+
 // NewProvider creates a new AWS [unused.Provider].
 //
 // A valid EC2 client must be supplied in order to list the unused
 // resources. The metadata passed will be used to identify the
 // provider.
-func NewProvider(client *ec2.Client, meta unused.Meta) (*Provider, error) {
+func NewProvider(client *ec2.Client, profile string, meta unused.Meta) (*Provider, error) {
 	if meta == nil {
 		meta = make(unused.Meta)
 	}
 
 	return &Provider{
-		client: client,
-		meta:   meta,
+		client:  client,
+		profile: profile,
+		meta:    meta,
 	}, nil
 }
 

--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -22,7 +22,7 @@ func TestNewProvider(t *testing.T) {
 		t.Fatalf("cannot load AWS config: %v", err)
 	}
 
-	p, err := aws.NewProvider(ec2.NewFromConfig(cfg), nil)
+	p, err := aws.NewProvider(ec2.NewFromConfig(cfg), "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestProviderMeta(t *testing.T) {
 			t.Fatalf("cannot load AWS config: %v", err)
 		}
 
-		return aws.NewProvider(ec2.NewFromConfig(cfg), meta)
+		return aws.NewProvider(ec2.NewFromConfig(cfg), "", meta)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -121,7 +121,7 @@ func TestListUnusedDisks(t *testing.T) {
 		t.Fatalf("cannot load AWS config: %v", err)
 	}
 
-	p, err := aws.NewProvider(ec2.NewFromConfig(cfg), nil)
+	p, err := aws.NewProvider(ec2.NewFromConfig(cfg), "profile", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/azure/provider.go
+++ b/azure/provider.go
@@ -15,8 +15,9 @@ const ResourceGroupMetaKey = "resource-group"
 
 // Providcer implements [unused.Provider] for Azure.
 type Provider struct {
-	client compute.DisksClient
-	meta   unused.Meta
+	client       compute.DisksClient
+	subscription string
+	meta         unused.Meta
 }
 
 // Name returns Azure.
@@ -24,6 +25,9 @@ func (p *Provider) Name() string { return "Azure" }
 
 // Meta returns the provider metadata.
 func (p *Provider) Meta() unused.Meta { return p.meta }
+
+// Meta returns the subscription for this provider.
+func (p *Provider) Id() string { return p.subscription }
 
 // NewProvider creates a new Azure [unused.Provider].
 //
@@ -34,7 +38,7 @@ func NewProvider(client compute.DisksClient, meta unused.Meta) (*Provider, error
 		meta = make(unused.Meta)
 	}
 
-	return &Provider{client: client, meta: meta}, nil
+	return &Provider{client: client, subscription: client.SubscriptionID, meta: meta}, nil
 }
 
 // ListUnusedDisks returns all the Azure compute disks that are not

--- a/cmd/internal/providers.go
+++ b/cmd/internal/providers.go
@@ -41,7 +41,7 @@ func CreateProviders(ctx context.Context, logger *slog.Logger, gcpProjects, awsP
 			return nil, fmt.Errorf("cannot load AWS config for profile %s: %w", profile, err)
 		}
 
-		p, err := aws.NewProvider(ec2.NewFromConfig(cfg), map[string]string{"profile": profile})
+		p, err := aws.NewProvider(ec2.NewFromConfig(cfg), profile, map[string]string{"profile": profile})
 		if err != nil {
 			return nil, fmt.Errorf("creating AWS provider for profile %s: %w", profile, err)
 		}

--- a/cmd/unused-exporter/config.go
+++ b/cmd/unused-exporter/config.go
@@ -21,7 +21,8 @@ type config struct {
 	}
 
 	Collector struct {
-		Timeout time.Duration
+		Timeout      time.Duration
+		PollInterval time.Duration
 	}
 
 	Logger *slog.Logger

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -171,6 +171,7 @@ func (e *exporter) pollProvider(p unused.Provider) {
 					slog.Time("created", d.CreatedAt()),
 				}
 				logger.Info("unused disk found", diskLabels...)
+				meta := d.Meta()
 				ns := meta["kubernetes.io/created-for/pvc/namespace"]
 				di := diskInfoByNamespace[ns]
 				if di == nil {

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -112,7 +112,6 @@ func (e *exporter) pollProvider(p unused.Provider) {
 			ctx, cancel := context.WithTimeout(e.ctx, e.timeout)
 			defer cancel()
 
-			meta := p.Meta()
 			logger := e.logger.With(
 				slog.String("provider", p.Name()),
 				slog.String("provider_id", p.Id()),
@@ -125,17 +124,6 @@ func (e *exporter) pollProvider(p unused.Provider) {
 			dur := time.Since(start)
 
 			name := strings.ToLower(p.Name())
-			var pid string
-			switch name {
-			case "gcp":
-				pid = meta["project"]
-			case "aws":
-				pid = meta["profile"]
-			case "azure":
-				pid = meta["subscription"]
-			default:
-				pid = meta.String()
-			}
 
 			var ms []metric // TODO we can optimize this creation here and allocate memory only once
 
@@ -143,7 +131,7 @@ func (e *exporter) pollProvider(p unused.Provider) {
 				ms = append(ms, metric{
 					desc:   d,
 					value:  v,
-					labels: append([]string{name, pid}, lbls...),
+					labels: append([]string{name, p.Id()}, lbls...),
 				})
 			}
 

--- a/cmd/unused-exporter/main.go
+++ b/cmd/unused-exporter/main.go
@@ -31,6 +31,7 @@ func main() {
 	flag.StringVar(&cfg.Web.Path, "web.path", "/metrics", "path on which to expose metrics")
 	flag.StringVar(&cfg.Web.Address, "web.address", ":8080", "address to expose metrics and web interface")
 	flag.DurationVar(&cfg.Web.Timeout, "web.timeout", 5*time.Second, "timeout for shutting down the server")
+	flag.DurationVar(&cfg.Collector.PollInterval, "collect.interval", 5*60*time.Second, "interval to poll the cloud provider API for unused disks")
 
 	flag.Parse()
 

--- a/disks_test.go
+++ b/disks_test.go
@@ -12,9 +12,9 @@ func TestDisksSort(t *testing.T) {
 	var (
 		now = time.Now()
 
-		foo = unusedtest.NewProvider("foo", nil)
-		baz = unusedtest.NewProvider("baz", nil)
-		bar = unusedtest.NewProvider("bar", nil)
+		foo = unusedtest.NewProvider("foo", "foo-id", nil)
+		baz = unusedtest.NewProvider("baz", "baz-id", nil)
+		bar = unusedtest.NewProvider("bar", "bar-id", nil)
 
 		gcp = unusedtest.NewDisk("ghi", foo, now.Add(-10*time.Minute))
 		aws = unusedtest.NewDisk("abc", baz, now.Add(-5*time.Minute))

--- a/gcp/provider.go
+++ b/gcp/provider.go
@@ -32,6 +32,9 @@ func (p *Provider) Name() string { return "GCP" }
 // Meta returns the provider metadata.
 func (p *Provider) Meta() unused.Meta { return p.meta }
 
+// Id returns the GCP project for this provider.
+func (p *Provider) Id() string { return p.project }
+
 // NewProvider creates a new GCP [unused.Provider].
 //
 // A valid GCP compute service must be supplied in order to listed the

--- a/provider.go
+++ b/provider.go
@@ -7,6 +7,9 @@ type Provider interface {
 	// Name returns the provider name.
 	Name() string
 
+	// Id returns the project (GCP) or profile (AWS) or subscription (Azure) for this provider.
+	Id() string
+
 	// ListUnusedDisks returns a list of unused disks for the given
 	// provider.
 	ListUnusedDisks(ctx context.Context) (Disks, error)

--- a/unusedtest/disk_test.go
+++ b/unusedtest/disk_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDisk(t *testing.T) {
-	p := unusedtest.NewProvider("my-provider", nil)
+	p := unusedtest.NewProvider("my-provider", "my-id", nil)
 	createdAt := time.Now().Round(0)
 	d := unusedtest.NewDisk("my-disk", p, createdAt)
 

--- a/unusedtest/provider.go
+++ b/unusedtest/provider.go
@@ -13,20 +13,23 @@ var _ unused.Provider = &Provider{}
 // Provider implements [unused.Provider] for testing purposes.
 type Provider struct {
 	name  string
+	id    string
 	disks unused.Disks
 	meta  unused.Meta
 }
 
 // NewProvider returns a new test provider that return the given disks
 // as unused.
-func NewProvider(name string, meta unused.Meta, disks ...unused.Disk) *Provider {
+func NewProvider(name string, id string, meta unused.Meta, disks ...unused.Disk) *Provider {
 	if meta == nil {
 		meta = make(unused.Meta)
 	}
-	return &Provider{name, disks, meta}
+	return &Provider{name, id, disks, meta}
 }
 
 func (p *Provider) Name() string { return p.name }
+
+func (p *Provider) Id() string { return p.id }
 
 func (p *Provider) Meta() unused.Meta { return p.meta }
 

--- a/unusedtest/provider_test.go
+++ b/unusedtest/provider_test.go
@@ -19,17 +19,22 @@ func init() {
 func TestNewProvider(t *testing.T) {
 	tests := []struct {
 		name  string
+		id    string
 		disks unused.Disks
 	}{
-		{"no-disks", nil},
+		{"no-disks", "my-id", nil},
 	}
 
 	for _, tt := range tests {
 		ctx := context.Background()
-		p := unusedtest.NewProvider(tt.name, nil, tt.disks...)
+		p := unusedtest.NewProvider(tt.name, "my-id", nil, tt.disks...)
 
 		if p.Name() != tt.name {
 			t.Errorf("unexpected provider.Name() %q", p.Name())
+		}
+
+		if p.Id() != tt.id {
+			t.Errorf("unexpected provider.Id() %q", p.Id())
 		}
 
 		disks, err := p.ListUnusedDisks(ctx)
@@ -56,7 +61,7 @@ func TestProviderDelete(t *testing.T) {
 		now := time.Now()
 
 		disks := make(unused.Disks, 10)
-		p := unusedtest.NewProvider("my-provider", nil, disks...)
+		p := unusedtest.NewProvider("my-provider", "my-id", nil, disks...)
 		for i := 0; i < cap(disks); i++ {
 			disks[i] = unusedtest.NewDisk(fmt.Sprintf("disk-%03d", i), p, now)
 		}
@@ -127,7 +132,7 @@ func TestTestProviderMeta(t *testing.T) {
 
 	t.Run("returns nil metadata", func(t *testing.T) {
 		err := unusedtest.TestProviderMeta(func(unused.Meta) (unused.Provider, error) {
-			p := unusedtest.NewProvider("my-provider", nil)
+			p := unusedtest.NewProvider("my-provider", "my-id", nil)
 			p.SetMeta(nil)
 			return p, nil
 		})
@@ -144,7 +149,7 @@ func TestTestProviderMeta(t *testing.T) {
 				newMeta[k] = v
 				newMeta[v] = k
 			}
-			return unusedtest.NewProvider("my-provider", newMeta), nil
+			return unusedtest.NewProvider("my-provider", "my-id", newMeta), nil
 		})
 		if err == nil {
 			t.Fatal("expecting error")
@@ -158,7 +163,7 @@ func TestTestProviderMeta(t *testing.T) {
 			for k := range meta {
 				newMeta[k] = k
 			}
-			return unusedtest.NewProvider("my-provider", newMeta), nil
+			return unusedtest.NewProvider("my-provider", "my-id", newMeta), nil
 		})
 		if err == nil {
 			t.Fatal("expecting error")
@@ -167,7 +172,7 @@ func TestTestProviderMeta(t *testing.T) {
 
 	t.Run("passes all testes", func(t *testing.T) {
 		err := unusedtest.TestProviderMeta(func(meta unused.Meta) (unused.Provider, error) {
-			return unusedtest.NewProvider("my-provider", meta), nil
+			return unusedtest.NewProvider("my-provider", "my-id", meta), nil
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
# What

- Adding "Id" to the provider struct, to hold project/profile/subscription
- Reducing logging from all of disk.Meta() to name, size, created

# Why

Provider Id is grabbed via a switch statement in our exporter:

```go
			var pid string
			switch name {
			case "gcp":
				pid = meta["project"]
			case "aws":
				pid = meta["profile"]
			case "azure":
				pid = meta["subscription"]
			default:
				pid = meta.String()
			}
```

Which could be just stored on the provider itself, as we're already storing it in some way via the metadata.  This makes it a bit easier to grab.

As for logging, we are logging all metadata with the disk that is retrieved.  I think this could be potentially useful, but I'm not sure we're using it.  I'm not completely married to the idea, but I think it'll clean up the logs a bit.  Happy to add it back in if it's useful, just not sure we're using it.

# Log output Before and After:

### Before:

```
time=2023-12-01T16:03:09.214-05:00 level=INFO msg="unused disk found" provider=GCP metadata="project=grafanalabs-dev" provider=GCP name=gke-dev-us-central1-2e-pvc-fd83188e-fd67-4eaf-85f4-b88a9d921f4e created=2021-03-10T11:39:47.064-08:00 kubernetes.io/created-for/pv/name=pvc-fd83188e-fd67-4eaf-85f4-b88a9d921f4e kubernetes.io/created-for/pvc/name=elasticsearch-pvc-elasticsearch-5-server-0 kubernetes.io/created-for/pvc/namespace=integration zone=us-central1-f
...
time=2023-12-01T16:00:57.469-05:00 level=INFO msg="unused disk found" provider=AWS metadata="profile=workloads-prod" provider=AWS name=pvc-feaf1cf1-0a00-4af2-a7ba-b2ae64f0385f created=2023-11-27T10:39:41.731Z ebs.csi.aws.com/cluster=true kubernetes.io/created-for/pv/name=pvc-feaf1cf1-0a00-4af2-a7ba-b2ae64f0385f kubernetes.io/created-for/pvc/name=grafana-agent-helm-grafana-agent-helm-7 kubernetes.io/created-for/pvc/namespace=grafana-agent zone=us-east-2a
...
time=2023-12-01T16:05:16.958-05:00 level=INFO msg="unused disk found" provider=Azure metadata="subscription=179c4f30-ebd8-489e-92bc-fb64588dadb3" provider=Azure name=grafana-enterprise-win2006-dev_OsDisk_1_f9e292dd008d489aa5b4f4f07a57d568 created=2021-03-11T09:18:05.558Z location=northeurope resource-group=GRAFANA-ENTERPRISE-DEV
```

After:
```
time=2023-12-01T16:06:24.526-05:00 level=INFO msg="unused disk found" provider=GCP provider_id=grafanalabs-dev name=gke-dev-eu-west-3-acbe-pvc-e48c7ed2-0f70-46c2-a963-a81837f87bc7 size_gb=300 created=2023-05-26T03:56:33.014-07:00
...
time=2023-12-01T16:06:02.400-05:00 level=INFO msg="unused disk found" provider=AWS provider_id=workloads-prod name=pvc-ad79f24f-28e3-4fc7-8179-58e013159679 size_gb=100 created=2023-10-06T18:24:03.262Z
...
time=2023-12-01T16:07:01.034-05:00 level=INFO msg="unused disk found" provider=Azure provider_id=179c4f30-ebd8-489e-92bc-fb64588dadb3 name=pvc-e56a18f0-3fad-40db-90ab-90f56cda0447 size_gb=130 created=2022-06-13T13:57:25.965Z
```