### PR TITLE
Logyball/cache updates followup / Verbose logging flag

### DIFF
--- a/cmd/unused-exporter/config.go
+++ b/cmd/unused-exporter/config.go
@@ -25,5 +25,6 @@ type config struct {
 		PollInterval time.Duration
 	}
 
-	Logger *slog.Logger
+	Logger         *slog.Logger
+	VerboseLogging bool
 }

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -149,9 +149,11 @@ func (e *exporter) pollProvider(p unused.Provider) {
 
 				meta := d.Meta()
 				if e.verbose {
+					groupLabels := make([]any, len(meta))
 					for _, k := range meta.Keys() {
-						diskLabels = append(diskLabels, slog.String(k, meta[k]))
+						groupLabels = append(groupLabels, slog.String(k, meta[k]))
 					}
+					diskLabels = append(diskLabels, slog.Group("meta", groupLabels...))
 				}
 
 				logger.Info("unused disk found", diskLabels...)

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -149,11 +149,11 @@ func (e *exporter) pollProvider(p unused.Provider) {
 
 				meta := d.Meta()
 				if e.verbose {
-					groupLabels := make([]any, len(meta))
+					diskMetaLabels := make([]any, 0, len(meta))
 					for _, k := range meta.Keys() {
-						groupLabels = append(groupLabels, slog.String(k, meta[k]))
+						diskMetaLabels = append(diskMetaLabels, slog.String(k, meta[k]))
 					}
-					diskLabels = append(diskLabels, slog.Group("meta", groupLabels...))
+					diskLabels = append(diskLabels, diskMetaLabels...)
 				}
 
 				logger.Info("unused disk found", diskLabels...)
@@ -214,9 +214,11 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 
 		if e.verbose {
 			providerMeta := p.Meta()
+			providerMetaLabels := make([]any, 0, len(providerMeta))
 			for _, k := range providerMeta.Keys() {
-				labels = append(labels, slog.String(k, providerMeta[k]))
+				providerMetaLabels = append(providerMetaLabels, slog.String(k, providerMeta[k]))
 			}
+			labels = append(labels, providerMetaLabels...)
 		}
 
 		e.logger.Info("reading provider cache", labels...)

--- a/cmd/unused-exporter/main.go
+++ b/cmd/unused-exporter/main.go
@@ -27,6 +27,7 @@ func main() {
 
 	internal.ProviderFlags(flag.CommandLine, &cfg.Providers.GCP, &cfg.Providers.AWS, &cfg.Providers.Azure)
 
+	flag.BoolVar(&cfg.VerboseLogging, "verbose", false, "add verbose logging information")
 	flag.DurationVar(&cfg.Collector.Timeout, "collect.timeout", 30*time.Second, "timeout for collecting metrics from each provider")
 	flag.StringVar(&cfg.Web.Path, "web.path", "/metrics", "path on which to expose metrics")
 	flag.StringVar(&cfg.Web.Address, "web.address", ":8080", "address to expose metrics and web interface")

--- a/disks_test.go
+++ b/disks_test.go
@@ -12,9 +12,9 @@ func TestDisksSort(t *testing.T) {
 	var (
 		now = time.Now()
 
-		foo = unusedtest.NewProvider("foo", "foo-id", nil)
-		baz = unusedtest.NewProvider("baz", "baz-id", nil)
-		bar = unusedtest.NewProvider("bar", "bar-id", nil)
+		foo = unusedtest.NewProvider("foo", nil)
+		baz = unusedtest.NewProvider("baz", nil)
+		bar = unusedtest.NewProvider("bar", nil)
 
 		gcp = unusedtest.NewDisk("ghi", foo, now.Add(-10*time.Minute))
 		aws = unusedtest.NewDisk("abc", baz, now.Add(-5*time.Minute))

--- a/unusedtest/disk_test.go
+++ b/unusedtest/disk_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDisk(t *testing.T) {
-	p := unusedtest.NewProvider("my-provider", "my-id", nil)
+	p := unusedtest.NewProvider("my-provider", nil)
 	createdAt := time.Now().Round(0)
 	d := unusedtest.NewDisk("my-disk", p, createdAt)
 

--- a/unusedtest/provider.go
+++ b/unusedtest/provider.go
@@ -13,23 +13,22 @@ var _ unused.Provider = &Provider{}
 // Provider implements [unused.Provider] for testing purposes.
 type Provider struct {
 	name  string
-	id    string
 	disks unused.Disks
 	meta  unused.Meta
 }
 
 // NewProvider returns a new test provider that return the given disks
 // as unused.
-func NewProvider(name string, id string, meta unused.Meta, disks ...unused.Disk) *Provider {
+func NewProvider(name string, meta unused.Meta, disks ...unused.Disk) *Provider {
 	if meta == nil {
 		meta = make(unused.Meta)
 	}
-	return &Provider{name, id, disks, meta}
+	return &Provider{name, disks, meta}
 }
 
 func (p *Provider) Name() string { return p.name }
 
-func (p *Provider) ID() string { return p.id }
+func (p *Provider) ID() string { return "my-id" }
 
 func (p *Provider) Meta() unused.Meta { return p.meta }
 

--- a/unusedtest/provider_test.go
+++ b/unusedtest/provider_test.go
@@ -27,7 +27,7 @@ func TestNewProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		ctx := context.Background()
-		p := unusedtest.NewProvider(tt.name, "my-id", nil, tt.disks...)
+		p := unusedtest.NewProvider(tt.name, nil, tt.disks...)
 
 		if p.Name() != tt.name {
 			t.Errorf("unexpected provider.Name() %q", p.Name())
@@ -61,7 +61,7 @@ func TestProviderDelete(t *testing.T) {
 		now := time.Now()
 
 		disks := make(unused.Disks, 10)
-		p := unusedtest.NewProvider("my-provider", "my-id", nil, disks...)
+		p := unusedtest.NewProvider("my-provider", nil, disks...)
 		for i := 0; i < cap(disks); i++ {
 			disks[i] = unusedtest.NewDisk(fmt.Sprintf("disk-%03d", i), p, now)
 		}
@@ -132,7 +132,7 @@ func TestTestProviderMeta(t *testing.T) {
 
 	t.Run("returns nil metadata", func(t *testing.T) {
 		err := unusedtest.TestProviderMeta(func(unused.Meta) (unused.Provider, error) {
-			p := unusedtest.NewProvider("my-provider", "my-id", nil)
+			p := unusedtest.NewProvider("my-provider", nil)
 			p.SetMeta(nil)
 			return p, nil
 		})
@@ -149,7 +149,7 @@ func TestTestProviderMeta(t *testing.T) {
 				newMeta[k] = v
 				newMeta[v] = k
 			}
-			return unusedtest.NewProvider("my-provider", "my-id", newMeta), nil
+			return unusedtest.NewProvider("my-provider", newMeta), nil
 		})
 		if err == nil {
 			t.Fatal("expecting error")
@@ -163,7 +163,7 @@ func TestTestProviderMeta(t *testing.T) {
 			for k := range meta {
 				newMeta[k] = k
 			}
-			return unusedtest.NewProvider("my-provider", "my-id", newMeta), nil
+			return unusedtest.NewProvider("my-provider", newMeta), nil
 		})
 		if err == nil {
 			t.Fatal("expecting error")
@@ -172,7 +172,7 @@ func TestTestProviderMeta(t *testing.T) {
 
 	t.Run("passes all testes", func(t *testing.T) {
 		err := unusedtest.TestProviderMeta(func(meta unused.Meta) (unused.Provider, error) {
-			return unusedtest.NewProvider("my-provider", "my-id", meta), nil
+			return unusedtest.NewProvider("my-provider", meta), nil
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Follow up from other comments on PR #67 

- Adding hardcoded ID return for test provider
- Added rudimentary verbose logging flag

A more "proper" way to add the logging would probably be by using logging levels, but if we're simply adding verbose or not verbose, this is probably an ok starting point.