### PR TITLE
Adding Azure Environment var authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Both binaries are opinionated on how to authenticate against each Cloud Service 
 | Provider | Notes |
 |-|-|
 | GCP | Depends on [default credentials](https://cloud.google.com/docs/authentication/application-default-credentials) |
-| AWS | Uses profile names from your [credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) |
-| Azure | Requires [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) installed on the host and [signed in](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli) |
+| AWS | Uses profile names from your [credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) or `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` env variables |
+| Azure | Either specify an `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID`, or requires [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) installed on the host and [signed in](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli) |
 
 ### `unused` binary
 TUI tool to query all given providers and list them as a neat table.

--- a/cmd/internal/providers.go
+++ b/cmd/internal/providers.go
@@ -6,8 +6,10 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"os"
 
 	azcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -49,7 +51,14 @@ func CreateProviders(ctx context.Context, logger *slog.Logger, gcpProjects, awsP
 	}
 
 	if len(azureSubs) > 0 {
-		a, err := auth.NewAuthorizerFromCLI()
+		var a autorest.Authorizer
+		var err error
+
+		if os.Getenv("AZURE_CLIENT_ID") != "" && os.Getenv("AZURE_CLIENT_SECRET") != "" && os.Getenv("AZURE_TENANT_ID") != "" {
+			a, err = auth.NewAuthorizerFromEnvironment()
+		} else {
+			a, err = auth.NewAuthorizerFromCLI()
+		}
 		if err != nil {
 			return nil, fmt.Errorf("creating Azure authorizer: %w", err)
 		}


### PR DESCRIPTION
Adding the ability to authenticate to azure using the `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID` environment variables, also documenting this as well as the fact that the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` env vars will work as well.