### PR TITLE
Add metric for disk info & last update

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -22,7 +22,7 @@ func TestNewProvider(t *testing.T) {
 		t.Fatalf("cannot load AWS config: %v", err)
 	}
 
-	p, err := aws.NewProvider(ec2.NewFromConfig(cfg), nil)
+	p, err := aws.NewProvider(nil, ec2.NewFromConfig(cfg), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestProviderMeta(t *testing.T) {
 			t.Fatalf("cannot load AWS config: %v", err)
 		}
 
-		return aws.NewProvider(ec2.NewFromConfig(cfg), meta)
+		return aws.NewProvider(nil, ec2.NewFromConfig(cfg), meta)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -121,7 +121,7 @@ func TestListUnusedDisks(t *testing.T) {
 		t.Fatalf("cannot load AWS config: %v", err)
 	}
 
-	p, err := aws.NewProvider(ec2.NewFromConfig(cfg), nil)
+	p, err := aws.NewProvider(nil, ec2.NewFromConfig(cfg), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/internal/providers.go
+++ b/cmd/internal/providers.go
@@ -41,7 +41,7 @@ func CreateProviders(ctx context.Context, logger *logfmt.Logger, gcpProjects, aw
 			return nil, fmt.Errorf("cannot load AWS config for profile %s: %w", profile, err)
 		}
 
-		p, err := aws.NewProvider(ec2.NewFromConfig(cfg), map[string]string{"profile": profile})
+		p, err := aws.NewProvider(logger, ec2.NewFromConfig(cfg), map[string]string{"profile": profile})
 		if err != nil {
 			return nil, fmt.Errorf("creating AWS provider for profile %s: %w", profile, err)
 		}

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -150,11 +150,11 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 			for _, d := range disks {
 				m := d.Meta()
 
-ts := 0.0
-lastUsed := d.LastUsedAt()
-if !lastUsed.IsZero() {
-    ts = float64(lastUsed.UnixMilli())
-}				
+				var ts float64
+				lastUsed := d.LastUsedAt()
+				if !lastUsed.IsZero() {
+					ts = float64(lastUsed.UnixMilli())
+				}
 
 				if m.CreatedForPV() == "" {
 					continue

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -150,13 +150,11 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 			for _, d := range disks {
 				m := d.Meta()
 
-				var ts float64
-				lastUsed := d.LastUsedAt()
-				if lastUsed.IsZero() {
-					ts = 0.0
-				} else {
-					ts = float64(lastUsed.UnixMilli())
-				}
+ts := 0.0
+lastUsed := d.LastUsedAt()
+if !lastUsed.IsZero() {
+    ts = float64(lastUsed.UnixMilli())
+}				
 
 				if m.CreatedForPV() == "" {
 					continue

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -141,7 +141,7 @@ func (e *exporter) Collect(ch chan<- prometheus.Metric) {
 					labels[k] = meta[k]
 				}
 				e.logger.Log("unused disk found", labels)
-				countByNamespace[meta["kubernetes.io/created-for/pvc/namespace"]] += 1
+				countByNamespace[meta.CreatedForNamespace()] += 1
 			}
 			for ns, c := range countByNamespace {
 				ch <- prometheus.MustNewConstMetric(e.count, prometheus.GaugeValue, float64(c), name, pid, ns)

--- a/meta.go
+++ b/meta.go
@@ -33,23 +33,13 @@ func (m Meta) String() string {
 }
 
 func (m Meta) Equals(b Meta) bool {
-	akeys := m.Keys()
-	bkeys := b.Keys()
-
-	if len(akeys) != len(bkeys) {
+	if len(m) != len(b) {
 		return false
 	}
 
-	sort.Strings(akeys)
-	sort.Strings(bkeys)
-
 	for ak, av := range m {
 		bv, ok := b[ak]
-		if !ok {
-			return false
-		}
-
-		if av != bv {
+		if !ok || av != bv {
 			return false
 		}
 	}

--- a/meta.go
+++ b/meta.go
@@ -32,8 +32,66 @@ func (m Meta) String() string {
 	return s.String()
 }
 
+func (m Meta) Equals(b Meta) bool {
+	akeys := m.Keys()
+	bkeys := b.Keys()
+
+	if len(akeys) != len(bkeys) {
+		return false
+	}
+
+	sort.Strings(akeys)
+	sort.Strings(bkeys)
+
+	for ak, av := range m {
+		bv, ok := b[ak]
+		if !ok {
+			return false
+		}
+
+		if av != bv {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Matches returns true when the given key exists in the map with the
 // given value.
 func (m Meta) Matches(key, val string) bool {
 	return m[key] == val
+}
+
+func (m Meta) CreatedForPV() string {
+	return m.coalesce("kubernetes.io/created-for/pv/name", "kubernetes.io-created-for-pv-name")
+}
+
+func (m Meta) CreatedForPVC() string {
+	return m.coalesce("kubernetes.io/created-for/pvc/name", "kubernetes.io-created-for-pvc-name")
+}
+
+func (m Meta) CreatedForNamespace() string {
+	return m.coalesce("kubernetes.io/created-for/pvc/namespace", "kubernetes.io-created-for-pvc-namespace")
+}
+
+func (m Meta) CreatedBy() string {
+	return m.coalesce("storage.gke.io/created-by", "created-by")
+}
+
+func (m Meta) Zone() string {
+	return m.coalesce("zone", "location")
+}
+
+func (m Meta) coalesce(keys ...string) string {
+	for _, k := range keys {
+		v, ok := m[k]
+		if !ok {
+			continue
+		}
+
+		return v
+	}
+
+	return ""
 }


### PR DESCRIPTION
This PR adds a `unused_disks_last_used_at` metric which exports the disk, PVC, and PV identifiers. The value of the gauge is the last time the disk was mounted (although this is only available on GCP for now).

I want to use this metric to create an alert for a PVC which exists without its underlying disk/volume, which happened to my team recently when we ran a script to cleanup unused disks (but it didn't clean up the associated PVCs).

To my knowledge, neither `opencost` nor `kube-state-metrics` export a metric which allows 3-way correlation between PVCs, PVs, and their underlying disks.