### PR TITLE
Add metric to track the size and labels of individual disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It exposes the following metrics:
 |-|-|
 | `unused_disks_count` | How many unused disks are in this provider |
 | `unused_disks_size_gb` | Total size of unused disks in this provider in GB |
+| `unused_disk_size_bytes` | Size of each disk in bytes |
 | `unused_disks_last_used_at` | Last timestamp (unix ms) when this disk was used. GCP only! |
 | `unused_provider_duration_ms` | How long in milliseconds took to fetch this provider information |
 | `unused_provider_info` | CSP information |

--- a/aws/disk.go
+++ b/aws/disk.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"math"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -48,7 +47,7 @@ func (d *Disk) Meta() unused.Meta { return d.meta }
 func (d *Disk) SizeGB() int { return int(*d.Volume.Size) }
 
 // SizeBytes returns the size of this AWS EC2 volume in bytes.
-func (d *Disk) SizeBytes() int { return int(*d.Volume.Size) * int(math.Pow(1024, 3)) }
+func (d *Disk) SizeBytes() float64 { return float64(*d.Volume.Size * 1073741824) }
 
 // LastUsedAt returns a zero [time.Time] value, as AWS does not
 // provide this information.

--- a/aws/disk.go
+++ b/aws/disk.go
@@ -7,6 +7,8 @@ import (
 	"github.com/grafana/unused"
 )
 
+const GiBbytes = 1073741824
+
 var _ unused.Disk = &Disk{}
 
 // Disk holds information about an AWS EC2 volume.
@@ -47,7 +49,7 @@ func (d *Disk) Meta() unused.Meta { return d.meta }
 func (d *Disk) SizeGB() int { return int(*d.Volume.Size) }
 
 // SizeBytes returns the size of this AWS EC2 volume in bytes.
-func (d *Disk) SizeBytes() float64 { return float64(*d.Volume.Size * 1073741824) }
+func (d *Disk) SizeBytes() float64 { return float64(*d.Volume.Size) * GiBbytes }
 
 // LastUsedAt returns a zero [time.Time] value, as AWS does not
 // provide this information.

--- a/aws/disk.go
+++ b/aws/disk.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"math"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -43,8 +44,11 @@ func (d *Disk) CreatedAt() time.Time { return *d.Volume.CreateTime }
 // Meta returns the disk metadata.
 func (d *Disk) Meta() unused.Meta { return d.meta }
 
-// SizeGB returns the size of this AWS EC2 volume in GB.
+// SizeGB returns the size of this AWS EC2 volume in GiB.
 func (d *Disk) SizeGB() int { return int(*d.Volume.Size) }
+
+// SizeBytes returns the size of this AWS EC2 volume in bytes.
+func (d *Disk) SizeBytes() int { return int(*d.Volume.Size) * int(math.Pow(1024, 3)) }
 
 // LastUsedAt returns a zero [time.Time] value, as AWS does not
 // provide this information.

--- a/azure/disk.go
+++ b/azure/disk.go
@@ -30,7 +30,7 @@ func (d *Disk) Name() string { return *d.Disk.Name }
 func (d *Disk) SizeGB() int { return int(*d.Disk.DiskSizeGB) }
 
 // SizeBytes returns the size of this Azure compute disk in bytes.
-func (d *Disk) SizeBytes() int { return int(*d.Disk.DiskSizeBytes) }
+func (d *Disk) SizeBytes() float64 { return float64(*d.Disk.DiskSizeBytes) }
 
 // CreatedAt returns the time when this Azure compute disk was
 // created.

--- a/azure/disk.go
+++ b/azure/disk.go
@@ -29,6 +29,9 @@ func (d *Disk) Name() string { return *d.Disk.Name }
 // SizeGB returns the size of this Azure compute disk in GB.
 func (d *Disk) SizeGB() int { return int(*d.Disk.DiskSizeGB) }
 
+// SizeBytes returns the size of this Azure compute disk in bytes.
+func (d *Disk) SizeBytes() int { return int(*d.Disk.DiskSizeBytes) }
+
 // CreatedAt returns the time when this Azure compute disk was
 // created.
 func (d *Disk) CreatedAt() time.Time { return d.Disk.TimeCreated.ToTime() }

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -32,6 +32,7 @@ type exporter struct {
 
 	info  *prometheus.Desc
 	count *prometheus.Desc
+	ds    *prometheus.Desc
 	size  *prometheus.Desc
 	dur   *prometheus.Desc
 	suc   *prometheus.Desc
@@ -62,6 +63,11 @@ func registerExporter(ctx context.Context, providers []unused.Provider, cfg conf
 			prometheus.BuildFQName(namespace, "disks", "count"),
 			"How many unused disks are in this provider",
 			append(labels, "k8s_namespace"),
+			nil),
+		ds: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "disk", "size_bytes"),
+			"Disk size in bytes",
+			append(labels, []string{"disk", "k8s_namespace", "type", "zone"}...),
 			nil),
 
 		size: prometheus.NewDesc(
@@ -177,6 +183,7 @@ func (e *exporter) pollProvider(p unused.Provider) {
 				}
 
 				addMetric(&ms, p, e.dlu, lastUsedTS(d), d.ID(), m.CreatedForPV(), m.CreatedForPVC(), m.Zone())
+				addMetric(&ms, p, e.ds, float64(d.SizeBytes()), d.ID(), ns, string(d.DiskType()), m.Zone())
 			}
 
 			addMetric(&ms, p, e.info, 1)

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -183,7 +183,7 @@ func (e *exporter) pollProvider(p unused.Provider) {
 				}
 
 				addMetric(&ms, p, e.dlu, lastUsedTS(d), d.ID(), m.CreatedForPV(), m.CreatedForPVC(), m.Zone())
-				addMetric(&ms, p, e.ds, float64(d.SizeBytes()), d.ID(), ns, string(d.DiskType()), m.Zone())
+				addMetric(&ms, p, e.ds, d.SizeBytes(), d.ID(), ns, string(d.DiskType()), m.Zone())
 			}
 
 			addMetric(&ms, p, e.info, 1)

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -67,7 +67,7 @@ func registerExporter(ctx context.Context, providers []unused.Provider, cfg conf
 		ds: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "disk", "size_bytes"),
 			"Disk size in bytes",
-			append(labels, []string{"disk", "k8s_namespace", "type", "zone"}...),
+			append(labels, []string{"disk", "k8s_namespace", "type", "region", "zone"}...),
 			nil),
 
 		size: prometheus.NewDesc(
@@ -183,7 +183,7 @@ func (e *exporter) pollProvider(p unused.Provider) {
 				}
 
 				addMetric(&ms, p, e.dlu, lastUsedTS(d), d.ID(), m.CreatedForPV(), m.CreatedForPVC(), m.Zone())
-				addMetric(&ms, p, e.ds, d.SizeBytes(), d.ID(), ns, string(d.DiskType()), m.Zone())
+				addMetric(&ms, p, e.ds, d.SizeBytes(), d.ID(), ns, string(d.DiskType()), getRegionFromZone(p, m.Zone()), m.Zone())
 			}
 
 			addMetric(&ms, p, e.info, 1)
@@ -283,4 +283,13 @@ func lastUsedTS(d unused.Disk) float64 {
 	}
 
 	return float64(lastUsed.UnixMilli())
+}
+
+func getRegionFromZone(p unused.Provider, z string) string {
+	if strings.ToLower(p.Name()) == "azure" {
+		return z
+	}
+
+	// Drop the last character to get the region from the zone for GCP and AWS
+	return z[:len(z)-1]
 }

--- a/disk.go
+++ b/disk.go
@@ -19,7 +19,7 @@ type Disk interface {
 	SizeGB() int
 
 	// SizeBytes returns the disk size in bytes.
-	SizeBytes() int
+	SizeBytes() float64
 
 	// CreatedAt returns the time when the disk was created.
 	CreatedAt() time.Time

--- a/disk.go
+++ b/disk.go
@@ -15,8 +15,11 @@ type Disk interface {
 	// Name returns the disk name.
 	Name() string
 
-	// SizeGB returns the disk size in GB.
+	// SizeGB returns the disk size in GB (Azure/GCP) and GiB for AWS.
 	SizeGB() int
+
+	// SizeBytes returns the disk size in bytes.
+	SizeBytes() int
 
 	// CreatedAt returns the time when the disk was created.
 	CreatedAt() time.Time

--- a/gcp/disk.go
+++ b/gcp/disk.go
@@ -9,6 +9,8 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
+const GBbytes = 1_000_000_000
+
 // ensure we are properly defining the interface
 var _ unused.Disk = &Disk{}
 
@@ -52,7 +54,7 @@ func (d *Disk) LastUsedAt() time.Time {
 func (d *Disk) SizeGB() int { return int(d.Disk.SizeGb) }
 
 // SizeBytes returns the size of the GCP compute disk in bytes.
-func (d *Disk) SizeBytes() float64 { return float64(d.Disk.SizeGb * 1_000_000_000) }
+func (d *Disk) SizeBytes() float64 { return float64(d.Disk.SizeGb) * GBbytes }
 
 // DiskType Type returns the type of the GCP compute disk.
 func (d *Disk) DiskType() unused.DiskType {

--- a/gcp/disk.go
+++ b/gcp/disk.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -50,6 +51,9 @@ func (d *Disk) LastUsedAt() time.Time {
 
 // SizeGB returns the size of the GCP compute disk in GB.
 func (d *Disk) SizeGB() int { return int(d.Disk.SizeGb) }
+
+// SizeBytes returns the size of the GCP compute disk in bytes.
+func (d *Disk) SizeBytes() int { return int(d.Disk.SizeGb) * int(math.Pow(1000, 3)) }
 
 // DiskType Type returns the type of the GCP compute disk.
 func (d *Disk) DiskType() unused.DiskType {

--- a/gcp/disk.go
+++ b/gcp/disk.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -53,7 +52,7 @@ func (d *Disk) LastUsedAt() time.Time {
 func (d *Disk) SizeGB() int { return int(d.Disk.SizeGb) }
 
 // SizeBytes returns the size of the GCP compute disk in bytes.
-func (d *Disk) SizeBytes() int { return int(d.Disk.SizeGb) * int(math.Pow(1000, 3)) }
+func (d *Disk) SizeBytes() float64 { return float64(d.Disk.SizeGb * 1_000_000_000) }
 
 // DiskType Type returns the type of the GCP compute disk.
 func (d *Disk) DiskType() unused.DiskType {

--- a/unusedtest/disk.go
+++ b/unusedtest/disk.go
@@ -1,6 +1,7 @@
 package unusedtest
 
 import (
+	"math"
 	"time"
 
 	"github.com/grafana/unused"
@@ -30,4 +31,5 @@ func (d Disk) CreatedAt() time.Time      { return d.createdAt }
 func (d Disk) Meta() unused.Meta         { return d.meta }
 func (d Disk) LastUsedAt() time.Time     { return d.createdAt.Add(1 * time.Minute) }
 func (d Disk) SizeGB() int               { return d.size }
+func (d Disk) SizeBytes() int            { return d.size * int(math.Pow(1000, 3)) }
 func (d Disk) DiskType() unused.DiskType { return d.diskType }

--- a/unusedtest/disk.go
+++ b/unusedtest/disk.go
@@ -1,13 +1,14 @@
 package unusedtest
 
 import (
-	"math"
 	"time"
 
 	"github.com/grafana/unused"
 )
 
 var _ unused.Disk = Disk{}
+
+const GBbytes = 1_000_000_000
 
 // Disk implements [unused.Disk] for testing purposes.
 type Disk struct {
@@ -31,5 +32,5 @@ func (d Disk) CreatedAt() time.Time      { return d.createdAt }
 func (d Disk) Meta() unused.Meta         { return d.meta }
 func (d Disk) LastUsedAt() time.Time     { return d.createdAt.Add(1 * time.Minute) }
 func (d Disk) SizeGB() int               { return d.size }
-func (d Disk) SizeBytes() int            { return d.size * int(math.Pow(1000, 3)) }
+func (d Disk) SizeBytes() float64        { return float64(d.size) * GBbytes }
 func (d Disk) DiskType() unused.DiskType { return d.diskType }


### PR DESCRIPTION
Re: https://github.com/grafana/deployment_tools/issues/111858

Once the disks are detached from the cluster, the only way back to knowing where they belonged is by using the namespace and the zone. But some namespaces exist in different zones/clusters (ie, generic names like `hosted-exporters`). The current `unused_disks_size_gb` metric was adding up the sizes of all disks under the same namespace. In the case of unique namespaces, that's alright. But in the case of those that span multiple regions, it can lead to costs being associated to the wrong cluster, and somewhat difficult to interpret data.

To make it easier for future us, I'm adding a new `unused_disk_size_bytes` metric here, that publishes the size data per disk, instead of added up. It still carries the `k8s_namespace`, `type`, and `zone` labels, since we'll need all of them to be able to attribute costs appropriately.

I've also opted for bytes as the unit, since the size field is not uniform across providers. Azure and GCP offer the size of the volume in GB, while AWS uses GiB. Even though they all end up billing per GB 🙄 

I've tested this out locally both for AWS and GCP. I have not tested it for Azure. I'll work on that now.