### PR TITLE
fix getRegionFromZone(), add exporter_test.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint:
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run -c .golangci.yml
 
 docker:
-	docker build --build-arg=GIT_VERSION=$(GIT_VERSION) -t $(IMAGE_PREFIX)/unused -f Dockerfile.exporter .
+	docker build --build-arg=GIT_VERSION=$(GIT_VERSION) -t $(IMAGE_PREFIX)/unused -f Dockerfile.exporter . --load
 	docker tag $(IMAGE_PREFIX)/unused $(IMAGE_PREFIX)/unused:$(GIT_VERSION)
 
 push: docker

--- a/cmd/unused-exporter/exporter.go
+++ b/cmd/unused-exporter/exporter.go
@@ -265,11 +265,14 @@ func getDiskLabels(d unused.Disk, v bool) []any {
 
 func getNamespace(d unused.Disk, p unused.Provider) string {
 	switch p.Name() {
+	case gcp.ProviderName:
+		return d.Meta()["kubernetes.io/created-for/pvc/namespace"]
+	case aws.ProviderName:
+		return d.Meta()["kubernetes.io/created-for/pvc/namespace"]
 	case azure.ProviderName:
 		return d.Meta()["kubernetes.io-created-for-pvc-namespace"]
 	default:
-
-		return d.Meta()["kubernetes.io/created-for/pvc/namespace"]
+		panic("getNamespace(): unrecognized provider name:" + p.Name())
 	}
 }
 
@@ -291,14 +294,14 @@ func lastUsedTS(d unused.Disk) float64 {
 }
 
 func getRegionFromZone(p unused.Provider, z string) string {
-	var region string
 	switch p.Name() {
-	case azure.ProviderName:
-		region = z
 	case gcp.ProviderName:
-		region = z[:strings.LastIndex(z, "-")]
+		return z[:strings.LastIndex(z, "-")]
 	case aws.ProviderName:
-		region = z[:len(z)-1]
+		return z[:len(z)-1]
+	case azure.ProviderName:
+		return z
+	default:
+		panic("getRegionFromZone(): unrecognized provider name:" + p.Name())
 	}
-	return region
 }

--- a/cmd/unused-exporter/exporter_test.go
+++ b/cmd/unused-exporter/exporter_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"log/slog"
 	"reflect"
 	"testing"
@@ -15,13 +14,14 @@ import (
 
 type MockProvider struct {
 	unused.Provider
-	
+
 	name string
 }
 
 func (m MockProvider) Name() string { return m.name }
 
 type MockDisk struct {
+	unused.Disk
 	name      string
 	sizeGB    int
 	createdAt time.Time
@@ -40,28 +40,8 @@ func (d *MockDisk) CreatedAt() time.Time {
 	return d.createdAt
 }
 
-func (d *MockDisk) ID() string {
-	return ""
-}
-
-func (d *MockDisk) Provider() unused.Provider {
-	return nil
-}
-
 func (d *MockDisk) SizeGB() int {
 	return d.sizeGB
-}
-
-func (d *MockDisk) SizeBytes() float64 {
-	return 0
-}
-
-func (d *MockDisk) LastUsedAt() time.Time {
-	return time.Time{}
-}
-
-func (d *MockDisk) DiskType() unused.DiskType {
-	return ""
 }
 
 func TestGetRegionFromZone(t *testing.T) {

--- a/cmd/unused-exporter/exporter_test.go
+++ b/cmd/unused-exporter/exporter_test.go
@@ -14,34 +14,18 @@ import (
 )
 
 type MockProvider struct {
+	unused.Provider
+	
 	name string
 }
+
+func (m MockProvider) Name() string { return m.name }
 
 type MockDisk struct {
 	name      string
 	sizeGB    int
 	createdAt time.Time
 	meta      map[string]string
-}
-
-func (p *MockProvider) Name() string {
-	return p.name
-}
-
-func (p *MockProvider) Delete(context context.Context, d unused.Disk) error {
-	return nil
-}
-
-func (p *MockProvider) ID() string {
-	return ""
-}
-
-func (p *MockProvider) ListUnusedDisks(ctx context.Context) (unused.Disks, error) {
-	return nil, nil
-}
-
-func (p *MockProvider) Meta() unused.Meta {
-	return unused.Meta{}
 }
 
 func (d *MockDisk) Name() string {

--- a/cmd/unused-exporter/exporter_test.go
+++ b/cmd/unused-exporter/exporter_test.go
@@ -52,29 +52,18 @@ func TestGetRegionFromZone(t *testing.T) {
 		expected string
 	}
 
-	testCases := []testCase{
-		{
-			name:     "Azure",
-			provider: azure.ProviderName,
-			zone:     "eastus1",
-			expected: "eastus1",
-		},
-		{
-			name:     "GCP",
-			provider: gcp.ProviderName,
-			zone:     "us-central1-a",
-			expected: "us-central1",
-		},
-		{
-			name:     "AWS",
-			provider: aws.ProviderName,
-			zone:     "us-west-2a",
-			expected: "us-west-2",
-		},
+	testCases := map[string]struct{
+		provider string
+		zone     string
+		expected string
+	} {
+		"Azure": {azure.ProviderName, "eastus1", "eastus1"},
+		"GCP":   {gcp.ProviderName, "us-central1-a", "us-central1"},
+		"AWS":   {aws.ProviderName, "us-west-2a", "us-west-2"},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
 			p := &MockProvider{name: tc.provider}
 			result := getRegionFromZone(p, tc.zone)
 			if result != tc.expected {

--- a/cmd/unused-exporter/exporter_test.go
+++ b/cmd/unused-exporter/exporter_test.go
@@ -46,17 +46,12 @@ func (d *MockDisk) SizeGB() int {
 
 func TestGetRegionFromZone(t *testing.T) {
 	type testCase struct {
-		name     string
 		provider string
 		zone     string
 		expected string
 	}
 
-	testCases := map[string]struct {
-		provider string
-		zone     string
-		expected string
-	}{
+	testCases := map[string]testCase{
 		"Azure": {azure.ProviderName, "eastus1", "eastus1"},
 		"GCP":   {gcp.ProviderName, "us-central1-a", "us-central1"},
 		"AWS":   {aws.ProviderName, "us-west-2a", "us-west-2"},

--- a/cmd/unused-exporter/exporter_test.go
+++ b/cmd/unused-exporter/exporter_test.go
@@ -52,11 +52,11 @@ func TestGetRegionFromZone(t *testing.T) {
 		expected string
 	}
 
-	testCases := map[string]struct{
+	testCases := map[string]struct {
 		provider string
 		zone     string
 		expected string
-	} {
+	}{
 		"Azure": {azure.ProviderName, "eastus1", "eastus1"},
 		"GCP":   {gcp.ProviderName, "us-central1-a", "us-central1"},
 		"AWS":   {aws.ProviderName, "us-west-2a", "us-west-2"},
@@ -75,31 +75,27 @@ func TestGetRegionFromZone(t *testing.T) {
 
 func TestGetNamespace(t *testing.T) {
 	type testCase struct {
-		name     string
 		provider string
 		diskMeta map[string]string
 		expected string
 	}
 
-	testCases := []testCase{
-		{
-			name:     "Azure",
+	testCases := map[string]testCase{
+		"Azure": {
 			provider: azure.ProviderName,
 			diskMeta: map[string]string{
 				"kubernetes.io-created-for-pvc-namespace": "azure-namespace",
 			},
 			expected: "azure-namespace",
 		},
-		{
-			name:     "GCP",
+		"GCP": {
 			provider: gcp.ProviderName,
 			diskMeta: map[string]string{
 				"kubernetes.io/created-for/pvc/namespace": "gcp-namespace",
 			},
 			expected: "gcp-namespace",
 		},
-		{
-			name:     "AWS",
+		"AWS": {
 			provider: aws.ProviderName,
 			diskMeta: map[string]string{
 				"kubernetes.io/created-for/pvc/namespace": "aws-namespace",
@@ -108,8 +104,8 @@ func TestGetNamespace(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
 			p := &MockProvider{name: tc.provider}
 			d := &MockDisk{meta: tc.diskMeta}
 			result := getNamespace(d, p)
@@ -122,7 +118,6 @@ func TestGetNamespace(t *testing.T) {
 
 func TestGetDiskLabels(t *testing.T) {
 	type testCase struct {
-		name     string
 		verbose  bool
 		disk     *MockDisk
 		expected []any
@@ -130,9 +125,8 @@ func TestGetDiskLabels(t *testing.T) {
 
 	createdAt := time.Now()
 
-	testCases := []testCase{
-		{
-			name:    "Basic Disk Labels",
+	testCases := map[string]testCase{
+		"Basic Disk Labels": {
 			verbose: false,
 			disk: &MockDisk{
 				name:      "test-disk",
@@ -146,8 +140,7 @@ func TestGetDiskLabels(t *testing.T) {
 				slog.Time("created", createdAt),
 			},
 		},
-		{
-			name:    "Verbose Disk Labels",
+		"Verbose Disk Labels": {
 			verbose: true,
 			disk: &MockDisk{
 				name:      "test-disk",
@@ -168,8 +161,8 @@ func TestGetDiskLabels(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
 			actual := getDiskLabels(tc.disk, tc.verbose)
 			if !reflect.DeepEqual(actual, tc.expected) {
 				t.Errorf("getDiskLabels(%v, %v) = %v, expected %v", tc.disk, tc.verbose, actual, tc.expected)

--- a/cmd/unused-exporter/exporter_test.go
+++ b/cmd/unused-exporter/exporter_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/grafana/unused"
+	"github.com/grafana/unused/aws"
+	"github.com/grafana/unused/azure"
+	"github.com/grafana/unused/gcp"
+)
+
+type MockProvider struct {
+	name string
+}
+
+type MockDisk struct {
+	name      string
+	sizeGB    int
+	createdAt time.Time
+	meta      map[string]string
+}
+
+func (p *MockProvider) Name() string {
+	return p.name
+}
+
+func (p *MockProvider) Delete(context context.Context, d unused.Disk) error {
+	return nil
+}
+
+func (p *MockProvider) ID() string {
+	return ""
+}
+
+func (p *MockProvider) ListUnusedDisks(ctx context.Context) (unused.Disks, error) {
+	return nil, nil
+}
+
+func (p *MockProvider) Meta() unused.Meta {
+	return unused.Meta{}
+}
+
+func (d *MockDisk) Name() string {
+	return d.name
+}
+
+func (d *MockDisk) Meta() unused.Meta {
+	return d.meta
+}
+
+func (d *MockDisk) CreatedAt() time.Time {
+	return d.createdAt
+}
+
+func (d *MockDisk) ID() string {
+	return ""
+}
+
+func (d *MockDisk) Provider() unused.Provider {
+	return nil
+}
+
+func (d *MockDisk) SizeGB() int {
+	return d.sizeGB
+}
+
+func (d *MockDisk) SizeBytes() float64 {
+	return 0
+}
+
+func (d *MockDisk) LastUsedAt() time.Time {
+	return time.Time{}
+}
+
+func (d *MockDisk) DiskType() unused.DiskType {
+	return ""
+}
+
+func TestGetRegionFromZone(t *testing.T) {
+	type testCase struct {
+		name     string
+		provider string
+		zone     string
+		expected string
+	}
+
+	testCases := []testCase{
+		{
+			name:     "Azure",
+			provider: azure.ProviderName,
+			zone:     "eastus1",
+			expected: "eastus1",
+		},
+		{
+			name:     "GCP",
+			provider: gcp.ProviderName,
+			zone:     "us-central1-a",
+			expected: "us-central1",
+		},
+		{
+			name:     "AWS",
+			provider: aws.ProviderName,
+			zone:     "us-west-2a",
+			expected: "us-west-2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &MockProvider{name: tc.provider}
+			result := getRegionFromZone(p, tc.zone)
+			if result != tc.expected {
+				t.Errorf("getRegionFromZone(%s, %s) = %s, expected %s", tc.provider, tc.zone, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetNamespace(t *testing.T) {
+	type testCase struct {
+		name     string
+		provider string
+		diskMeta map[string]string
+		expected string
+	}
+
+	testCases := []testCase{
+		{
+			name:     "Azure",
+			provider: azure.ProviderName,
+			diskMeta: map[string]string{
+				"kubernetes.io-created-for-pvc-namespace": "azure-namespace",
+			},
+			expected: "azure-namespace",
+		},
+		{
+			name:     "GCP",
+			provider: gcp.ProviderName,
+			diskMeta: map[string]string{
+				"kubernetes.io/created-for/pvc/namespace": "gcp-namespace",
+			},
+			expected: "gcp-namespace",
+		},
+		{
+			name:     "AWS",
+			provider: aws.ProviderName,
+			diskMeta: map[string]string{
+				"kubernetes.io/created-for/pvc/namespace": "aws-namespace",
+			},
+			expected: "aws-namespace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &MockProvider{name: tc.provider}
+			d := &MockDisk{meta: tc.diskMeta}
+			result := getNamespace(d, p)
+			if result != tc.expected {
+				t.Errorf("getNamespace(%v, %v) = %s, expected %s", d, p, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetDiskLabels(t *testing.T) {
+	type testCase struct {
+		name     string
+		verbose  bool
+		disk     *MockDisk
+		expected []any
+	}
+
+	createdAt := time.Now()
+
+	testCases := []testCase{
+		{
+			name:    "Basic Disk Labels",
+			verbose: false,
+			disk: &MockDisk{
+				name:      "test-disk",
+				sizeGB:    100,
+				createdAt: createdAt,
+				meta:      map[string]string{},
+			},
+			expected: []any{
+				slog.String("name", "test-disk"),
+				slog.Int("size_gb", 100),
+				slog.Time("created", createdAt),
+			},
+		},
+		{
+			name:    "Verbose Disk Labels",
+			verbose: true,
+			disk: &MockDisk{
+				name:      "test-disk",
+				sizeGB:    100,
+				createdAt: createdAt,
+				meta: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expected: []any{
+				slog.String("name", "test-disk"),
+				slog.Int("size_gb", 100),
+				slog.Time("created", createdAt),
+				slog.String("key1", "value1"),
+				slog.String("key2", "value2"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getDiskLabels(tc.disk, tc.verbose)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("getDiskLabels(%v, %v) = %v, expected %v", tc.disk, tc.verbose, actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Changes overview:

* `exporter.go`:
  *  Fix `getRegionFromZone()`, also make other functions use `<provider>.ProviderName` recently added (instead of fixed strings)
* `exporter_test.go`:
  *  Add test coverage to some functions, including the one fixed above
* `Dockerfile`:
  *  add `--load` to `Dockerfile` to support buildx setups.

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
