### PR TITLE
Upgrade Go version used in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21
+        go-version: 1.22
 
     - name: Test
       run: make test
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21
+        go-version: 1.22
 
     - name: Checks
       run: make checks

--- a/cmd/unused-exporter/server.go
+++ b/cmd/unused-exporter/server.go
@@ -24,7 +24,7 @@ func runWebServer(ctx context.Context, cfg config) error {
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/" {
-			fmt.Fprintf(w, indexTemplate, cfg.Web.Path)
+			fmt.Fprintf(w, indexTemplate, cfg.Web.Path) // nolint:errcheck
 		} else {
 			http.NotFound(w, req)
 		}

--- a/cmd/unused/internal/ui/group_table.go
+++ b/cmd/unused/internal/ui/group_table.go
@@ -47,7 +47,7 @@ func GroupTable(ctx context.Context, options Options) error {
 	totalSize := make(map[groupKey]int)
 	totalCount := make(map[groupKey]int)
 
-	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	fmt.Fprintln(w, strings.Join(headers, "\t")) // nolint:errcheck
 
 	var aggrValue string
 	for _, d := range disks {
@@ -79,7 +79,7 @@ func GroupTable(ctx context.Context, options Options) error {
 	for _, aggrKey := range keys {
 		row := aggrKey[:]
 		row = append(row, strconv.Itoa(totalCount[aggrKey]), strconv.Itoa(totalSize[aggrKey]))
-		fmt.Fprintln(w, strings.Join(row, "\t"))
+		fmt.Fprintln(w, strings.Join(row, "\t")) // nolint:errcheck
 	}
 
 	if err := w.Flush(); err != nil {

--- a/cmd/unused/internal/ui/table.go
+++ b/cmd/unused/internal/ui/table.go
@@ -43,7 +43,7 @@ func Table(ctx context.Context, options Options) error {
 		headers = append(headers, "PROVIDER_META", "DISK_META")
 	}
 
-	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	fmt.Fprintln(w, strings.Join(headers, "\t")) // nolint:errcheck
 
 	for _, d := range disks {
 		p := d.Provider()
@@ -57,7 +57,7 @@ func Table(ctx context.Context, options Options) error {
 			row = append(row, p.Meta().String(), d.Meta().String())
 		}
 
-		fmt.Fprintln(w, strings.Join(row, "\t"))
+		fmt.Fprintln(w, strings.Join(row, "\t")) // nolint:errcheck
 	}
 
 	if err := w.Flush(); err != nil {


### PR DESCRIPTION
This was first spotted in #100. The tools used in CI weren't compatible with Go 1.21 but Go 1.22.