### PR TITLE
Secure GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495
       with:
         go-version: 1.24
 


### PR DESCRIPTION
As a remediation from the [incident](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/) on April 26, 2025, we are securing our GitHub Actions using suggestions from [zizmor](https://woodruffw.github.io/zizmor/) and [trufflehog](https://trufflesecurity.com/).