### PR TITLE
[cmd/unused]: Add `-min-age` filter

### DIFF
--- a/cmd/internal/age.go
+++ b/cmd/internal/age.go
@@ -1,7 +1,10 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -23,4 +26,35 @@ func Age(date time.Time) string {
 	} else {
 		return fmt.Sprintf("%dy", d/(365*24*time.Hour))
 	}
+}
+
+var ErrInvalidAge = errors.New("invalid age")
+
+func ParseAge(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, ErrInvalidAge
+	}
+
+	var age time.Duration
+
+	days, s, ok := strings.Cut(s, "d")
+	if ok {
+		days, err := strconv.Atoi(days)
+		if err != nil {
+			return 0, fmt.Errorf("%w: %w", ErrInvalidAge, err)
+		}
+
+		age = time.Duration(days) * 24 * time.Hour
+	}
+
+	if s != "" {
+		dur, err := time.ParseDuration(s)
+		if err != nil {
+			return 0, fmt.Errorf("%w: %w", ErrInvalidAge, err)
+		}
+
+		age += dur
+	}
+
+	return age, nil
 }

--- a/cmd/internal/age_test.go
+++ b/cmd/internal/age_test.go
@@ -1,6 +1,7 @@
 package internal_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -30,5 +31,27 @@ func TestAge(t *testing.T) {
 				t.Errorf("expecting Age(%s) = %s, got %s", tt.in.Format(time.RFC3339), tt.exp, got)
 			}
 		})
+	}
+}
+
+func TestParseAge(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp time.Duration
+		err error
+	}{
+		{"23d", 23 * 24 * time.Hour, nil},
+		{"0d3h", 3 * time.Hour, nil},
+		{"d3h", 0, internal.ErrInvalidAge},
+		{"23dh", 0, internal.ErrInvalidAge},
+		{"23d3", 0, internal.ErrInvalidAge},
+		{"", 0, internal.ErrInvalidAge},
+	}
+
+	for _, tt := range tests {
+		got, err := internal.ParseAge(tt.in)
+		if !errors.Is(err, tt.err) || got != tt.exp {
+			t.Errorf("expecting ParseAge(%q) = (%v, %v), got (%v, %v)", tt.in, tt.exp, tt.err, got, err)
+		}
 	}
 }

--- a/cmd/unused/internal/ui/group_table.go
+++ b/cmd/unused/internal/ui/group_table.go
@@ -8,9 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
-	"time"
-
-	"github.com/grafana/unused"
 )
 
 // Disks are aggregated by the key composed by these 3 strings:
@@ -27,25 +24,7 @@ func GroupTable(ctx context.Context, options Options) error {
 		return err
 	}
 
-	if options.MinAge > 0 {
-		filtered := make(unused.Disks, 0, len(disks))
-		for _, d := range disks {
-			if time.Since(d.CreatedAt()) >= options.MinAge {
-				filtered = append(filtered, d)
-			}
-		}
-		disks = filtered
-	}
-
-	if options.Filter.Key != "" {
-		filtered := make(unused.Disks, 0, len(disks))
-		for _, d := range disks {
-			if d.Meta().Matches(options.Filter.Key, options.Filter.Value) {
-				filtered = append(filtered, d)
-			}
-		}
-		disks = filtered
-	}
+	disks = disks.Filter(options.FilterFunc)
 
 	if len(disks) == 0 {
 		fmt.Println("No disks found")

--- a/cmd/unused/internal/ui/group_table.go
+++ b/cmd/unused/internal/ui/group_table.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/grafana/unused"
 )
@@ -24,6 +25,16 @@ func GroupTable(ctx context.Context, options Options) error {
 	disks, err := listUnusedDisks(ctx, options.Providers)
 	if err != nil {
 		return err
+	}
+
+	if options.MinAge > 0 {
+		filtered := make(unused.Disks, 0, len(disks))
+		for _, d := range disks {
+			if time.Since(d.CreatedAt()) >= options.MinAge {
+				filtered = append(filtered, d)
+			}
+		}
+		disks = filtered
 	}
 
 	if options.Filter.Key != "" {

--- a/cmd/unused/internal/ui/interactive.go
+++ b/cmd/unused/internal/ui/interactive.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Interactive(ctx context.Context, options Options) error {
-	m := interactive.New(options.Providers, options.ExtraColumns, options.Filter.Key, options.Filter.Value, options.DryRun)
+	m := interactive.New(options.Providers, options.ExtraColumns, options.FilterFunc, options.DryRun)
 
 	if _, err := tea.NewProgram(m).Run(); err != nil {
 		return fmt.Errorf("cannot start interactive UI: %w", err)

--- a/cmd/unused/internal/ui/table.go
+++ b/cmd/unused/internal/ui/table.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 	"text/tabwriter"
-	"time"
 
 	"github.com/grafana/unused"
 	"github.com/grafana/unused/cmd/internal"
@@ -25,25 +24,7 @@ func Table(ctx context.Context, options Options) error {
 		return err
 	}
 
-	if options.MinAge > 0 {
-		filtered := make(unused.Disks, 0, len(disks))
-		for _, d := range disks {
-			if time.Since(d.CreatedAt()) >= options.MinAge {
-				filtered = append(filtered, d)
-			}
-		}
-		disks = filtered
-	}
-
-	if options.Filter.Key != "" {
-		filtered := make(unused.Disks, 0, len(disks))
-		for _, d := range disks {
-			if d.Meta().Matches(options.Filter.Key, options.Filter.Value) {
-				filtered = append(filtered, d)
-			}
-		}
-		disks = filtered
-	}
+	disks = disks.Filter(options.FilterFunc)
 
 	if len(disks) == 0 {
 		fmt.Println("No disks found")

--- a/cmd/unused/internal/ui/table.go
+++ b/cmd/unused/internal/ui/table.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"text/tabwriter"
+	"time"
 
 	"github.com/grafana/unused"
 	"github.com/grafana/unused/cmd/internal"
@@ -22,6 +23,16 @@ func Table(ctx context.Context, options Options) error {
 	disks, err := listUnusedDisks(ctx, options.Providers)
 	if err != nil {
 		return err
+	}
+
+	if options.MinAge > 0 {
+		filtered := make(unused.Disks, 0, len(disks))
+		for _, d := range disks {
+			if time.Since(d.CreatedAt()) >= options.MinAge {
+				filtered = append(filtered, d)
+			}
+		}
+		disks = filtered
 	}
 
 	if options.Filter.Key != "" {

--- a/cmd/unused/internal/ui/ui.go
+++ b/cmd/unused/internal/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"time"
 
 	"github.com/grafana/unused"
 )
@@ -17,6 +18,7 @@ type Options struct {
 	Group        string
 	Verbose      bool
 	DryRun       bool
+	MinAge       time.Duration
 }
 
 type DisplayFunc func(ctx context.Context, options Options) error

--- a/cmd/unused/internal/ui/ui.go
+++ b/cmd/unused/internal/ui/ui.go
@@ -21,6 +21,13 @@ type Options struct {
 	MinAge       time.Duration
 }
 
+func (o Options) FilterFunc(d unused.Disk) bool {
+	minAge := o.MinAge == 0 || time.Since(d.CreatedAt()) >= o.MinAge
+	keyVal := o.Filter.Key == "" || d.Meta().Matches(o.Filter.Key, o.Filter.Value)
+
+	return minAge && keyVal
+}
+
 type DisplayFunc func(ctx context.Context, options Options) error
 
 const (

--- a/cmd/unused/internal/ui/ui_test.go
+++ b/cmd/unused/internal/ui/ui_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/unused"
+	"github.com/grafana/unused/unusedtest"
+)
+
+func TestOptions_Filter(t *testing.T) {
+	var (
+		csp1 = unusedtest.NewProvider("foo", nil)
+		csp2 = unusedtest.NewProvider("bar", nil)
+
+		now = time.Now()
+
+		foo = unusedtest.NewDisk("foo", csp1, now.Add(-5*time.Hour))
+		bar = unusedtest.NewDisk("bar", csp2, now.Add(-5*time.Hour))
+		baz = unusedtest.NewDisk("baz", csp1, now.Add(-2*time.Hour))
+	)
+
+	foo.SetMeta(unused.Meta{"lorem": "ipsum"})
+	bar.SetMeta(unused.Meta{"lorem": "ipsum", "dolor": "sit amet"})
+	baz.SetMeta(unused.Meta{"lorem": "quux"})
+
+	disks := unused.Disks{foo, bar, baz}
+
+	eq := func(a, b unused.Disks) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, e := range a {
+			if b[i].Name() != e.Name() {
+				return false
+			}
+		}
+		return true
+	}
+
+	tests := map[string]struct {
+		minAge   time.Duration
+		key, val string
+		exp      unused.Disks
+	}{
+		"no filter": {0, "", "", disks},
+
+		"minage": {3 * time.Hour, "", "", unused.Disks{foo, bar}},
+		"keyval": {0, "dolor", "sit amet", unused.Disks{bar}},
+		"both":   {2 * time.Hour, "dolor", "", unused.Disks{foo, baz}},
+
+		"!minage": {10 * time.Hour, "", "", nil},
+		"!keyval": {0, "foo", "bar", nil},
+		"!both":   {10 * time.Hour, "foo", "bar", nil},
+	}
+
+	for n, tt := range tests {
+		t.Run(n, func(t *testing.T) {
+			opts := Options{
+				MinAge: tt.minAge,
+				Filter: Filter{
+					Key:   tt.key,
+					Value: tt.val,
+				},
+			}
+
+			got := disks.Filter(opts.FilterFunc)
+			if !eq(got, tt.exp) {
+				for _, d := range disks {
+					t.Error(tt.key, tt.val, d.Meta())
+				}
+				t.Errorf("slices are not equal\nexp: %v\ngot: %v", tt.exp, got)
+			}
+		})
+	}
+}

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -57,6 +57,17 @@ func main() {
 		return nil
 	})
 
+	flag.Func("min-age", "Minimum age of the disk to be listed", func(s string) error {
+		dur, err := internal.ParseAge(s)
+		if err != nil {
+			return err
+		}
+
+		options.MinAge = dur
+
+		return nil
+	})
+
 	flag.Func("add-column", "Display additional column with metadata", func(c string) error {
 		options.ExtraColumns = append(options.ExtraColumns, c)
 		return nil

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -57,7 +57,7 @@ func main() {
 		return nil
 	})
 
-	flag.Func("min-age", "Minimum age of the disk to be listed", func(s string) error {
+	flag.Func("min-age", "Minimum age of the disk to be listed (ex: 365d or 36h)", func(s string) error {
 		dur, err := internal.ParseAge(s)
 		if err != nil {
 			return err

--- a/disks.go
+++ b/disks.go
@@ -5,6 +5,16 @@ import "sort"
 // Disks is a collection of Disk.
 type Disks []Disk
 
+func (d Disks) Filter(fn func(d Disk) bool) Disks {
+	r := make(Disks, 0, len(d))
+	for _, e := range d {
+		if fn(e) {
+			r = append(r, e)
+		}
+	}
+	return r
+}
+
 // ByFunc is the type of sorting functions for Disks.
 type ByFunc func(p, q Disk) bool
 

--- a/disks.go
+++ b/disks.go
@@ -5,7 +5,9 @@ import "sort"
 // Disks is a collection of Disk.
 type Disks []Disk
 
-func (d Disks) Filter(fn func(d Disk) bool) Disks {
+type FilterFunc func(d Disk) bool
+
+func (d Disks) Filter(fn FilterFunc) Disks {
 	r := make(Disks, 0, len(d))
 	for _, e := range d {
 		if fn(e) {

--- a/disks_test.go
+++ b/disks_test.go
@@ -1,6 +1,8 @@
 package unused_test
 
 import (
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,6 +104,11 @@ func TestDisksFilter(t *testing.T) {
 		if len(a) != len(b) {
 			return false
 		}
+
+		sortBy := func(a, b unused.Disk) int { return strings.Compare(a.Name(), b.Name()) }
+		slices.SortFunc(a, sortBy)
+		slices.SortFunc(b, sortBy)
+
 		for i, e := range a {
 			if b[i].Name() != e.Name() {
 				return false

--- a/disks_test.go
+++ b/disks_test.go
@@ -70,3 +70,48 @@ func assertEqualDisks(t *testing.T, p, q unused.Disk) {
 		}
 	}
 }
+
+func TestDisksFilter(t *testing.T) {
+	var (
+		now = time.Now()
+
+		foo = unusedtest.NewProvider("foo", nil)
+		baz = unusedtest.NewProvider("baz", nil)
+		bar = unusedtest.NewProvider("bar", nil)
+
+		gcp = unusedtest.NewDisk("ghi", foo, now.Add(-10*time.Minute))
+		aws = unusedtest.NewDisk("abc", baz, now.Add(-5*time.Minute))
+		az  = unusedtest.NewDisk("def", bar, now.Add(-2*time.Minute))
+
+		disks = unused.Disks{gcp, aws, az}
+	)
+
+	tests := []struct {
+		filter func(unused.Disk) bool
+		exp    unused.Disks
+	}{
+		{func(_ unused.Disk) bool { return true }, disks},
+		{func(_ unused.Disk) bool { return false }, nil},
+		{func(d unused.Disk) bool { return d.Provider().Name() == "baz" }, unused.Disks{aws}},
+		{func(d unused.Disk) bool { return d.Provider().Name() != "baz" }, unused.Disks{gcp, az}},
+	}
+
+	eq := func(a, b unused.Disks) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i, e := range a {
+			if b[i].Name() != e.Name() {
+				return false
+			}
+		}
+		return true
+	}
+
+	for i, tt := range tests {
+		got := disks.Filter(tt.filter)
+		if !eq(got, tt.exp) {
+			t.Errorf("case %d: slices are not equal\nexp: %v\ngot: %v", i, tt.exp, got)
+		}
+	}
+}

--- a/disks_test.go
+++ b/disks_test.go
@@ -94,6 +94,8 @@ func TestDisksFilter(t *testing.T) {
 		{func(_ unused.Disk) bool { return false }, nil},
 		{func(d unused.Disk) bool { return d.Provider().Name() == "baz" }, unused.Disks{aws}},
 		{func(d unused.Disk) bool { return d.Provider().Name() != "baz" }, unused.Disks{gcp, az}},
+		{func(d unused.Disk) bool { return d.CreatedAt().Before(now.Add(-1 * time.Hour)) }, nil},
+		{func(d unused.Disk) bool { return d.CreatedAt().Before(now.Add(-1 * time.Second)) }, unused.Disks{gcp, aws, az}},
 	}
 
 	eq := func(a, b unused.Disks) bool {

--- a/unusedtest/disk.go
+++ b/unusedtest/disk.go
@@ -32,3 +32,5 @@ func (d Disk) LastUsedAt() time.Time     { return d.createdAt.Add(1 * time.Minut
 func (d Disk) SizeGB() int               { return d.size }
 func (d Disk) SizeBytes() float64        { return float64(d.size) * unused.GiBbytes }
 func (d Disk) DiskType() unused.DiskType { return d.diskType }
+
+func (d *Disk) SetMeta(m unused.Meta) { d.meta = m }


### PR DESCRIPTION
This PR adds a new `-min-age` flag that allows the user to specify a minimum age for unused disks to be listed. It also adds a custom duration parsing function to allow users to specify a minimum age in days, rather than having to compute the number of hours, eg. `-min-age=75d` instead of `-min-age=1800h`.