### PR TITLE
[cmd/unused/internal] Add support for years in `ParseAge`

### DIFF
--- a/cmd/internal/age.go
+++ b/cmd/internal/age.go
@@ -52,8 +52,6 @@ func ParseAge(s string) (time.Duration, error) {
 			}
 			age += time.Duration(n) * ud.d
 			s = after
-		} else {
-			s = before
 		}
 	}
 

--- a/cmd/internal/age_test.go
+++ b/cmd/internal/age_test.go
@@ -50,6 +50,8 @@ func TestParseAge(t *testing.T) {
 		{"2x4d6h", 0, internal.ErrInvalidAge},
 		{"1y", 365 * 24 * time.Hour, nil},
 		{"3y7d14h", 3*365*24*time.Hour + 7*24*time.Hour + 14*time.Hour, nil},
+		{"1y2y3d", 0, internal.ErrInvalidAge},
+		{"1d2d3h", 0, internal.ErrInvalidAge},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
A few days ago I was using the tool to list unused disks older than 1 year, and while passing `-min-age=1y` it was returning all disks. Upon further inspection, I've found we didn't have support for years, which lead me to find that `ParseAge` wasn't failing when trying to parse `1y` and instead returning a duration of `0`.

This PR fixes `ParseAge` so if we ever pass an unrecognized unit it will fail with an error. It also adds support for `y` for indicating years, as it is much easier to pass `-min-age=3y` than `-min-age=1095d` 😬 (we [discussed](https://github.com/grafana/unused/pull/171#discussion_r2376827349) about this before, and decided not to add it; we were wrong.)