### PR TITLE
Add `azure.Disk.LastUsedAt`

### DIFF
--- a/azure/disk.go
+++ b/azure/disk.go
@@ -43,7 +43,14 @@ func (d *Disk) Meta() unused.Meta { return d.meta }
 
 // LastUsedAt returns the time when the Azure compute disk was last
 // detached.
-func (d *Disk) LastUsedAt() time.Time { return *d.Disk.Properties.LastOwnershipUpdateTime }
+func (d *Disk) LastUsedAt() time.Time {
+	if d.Disk.Properties.LastOwnershipUpdateTime == nil {
+		// Special case: disk was created manually and never used,
+		// return the creation time.
+		return d.CreatedAt()
+	}
+	return *d.Disk.Properties.LastOwnershipUpdateTime
+}
 
 // DiskType Type returns the type of this Azure compute disk.
 func (d *Disk) DiskType() unused.DiskType {

--- a/azure/disk_test.go
+++ b/azure/disk_test.go
@@ -67,4 +67,13 @@ func TestDisk(t *testing.T) {
 	if exp, got := float64(sizeBytes), d.SizeBytes(); exp != got {
 		t.Errorf("expecting SizeBytes() %f, got %f", exp, got)
 	}
+
+	t.Run("special case disk never used", func(t *testing.T) {
+		dd := d.(*Disk)
+		dd.Disk.Properties.LastOwnershipUpdateTime = nil
+
+		if !d.CreatedAt().Equal(d.LastUsedAt()) {
+			t.Errorf("expecting LastUsedAt() to be the same as CreatedAt() %v, got %v", d.CreatedAt(), d.LastUsedAt())
+		}
+	})
 }


### PR DESCRIPTION
Azure now returns this information as _the UTC time when the ownership state of the disk was last changed i.e., the time the disk was last attached or detached from a VM or the time when the VM to which the disk was attached was deallocated or started._