### PR TITLE
Fix `gcp.Disk.LastUsedAt`

### DIFF
--- a/gcp/disk.go
+++ b/gcp/disk.go
@@ -43,6 +43,12 @@ func (d *Disk) Meta() unused.Meta { return d.meta }
 // LastUsedAt returns the time when the GCP compute disk was last
 // detached.
 func (d *Disk) LastUsedAt() time.Time {
+	if d.Disk.LastDetachTimestamp == "" {
+		// Special case: disk was created manually and never used,
+		// return the creation time.
+		return d.CreatedAt()
+	}
+
 	// it's safe to assume GCP will send a valid timestamp
 	t, _ := time.Parse(time.RFC3339, d.Disk.LastDetachTimestamp)
 	return t

--- a/gcp/disk_test.go
+++ b/gcp/disk_test.go
@@ -58,4 +58,13 @@ func TestDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("metadata doesn't match: %v", err)
 	}
+
+	t.Run("special case disk never used", func(t *testing.T) {
+		dd := d.(*Disk)
+		dd.Disk.LastDetachTimestamp = ""
+
+		if !d.CreatedAt().Equal(d.LastUsedAt()) {
+			t.Errorf("expecting LastUsedAt() to be the same as CreatedAt() %v, got %v", d.CreatedAt(), d.LastUsedAt())
+		}
+	})
 }


### PR DESCRIPTION
If the disk was created manually and never used, this property will return an empty string, and thus we can consider it was the creation time for the purposes of treating it as an unused disk.