### PR TITLE
[cmd/unused] Add `-min-unused` filter

### DIFF
--- a/aws/provider_test.go
+++ b/aws/provider_test.go
@@ -18,13 +18,9 @@ import (
 )
 
 func TestNewProvider(t *testing.T) {
-	ctx := context.Background()
-	cfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		t.Fatalf("cannot load AWS config: %v", err)
-	}
+	cfg := awsutil.NewConfig()
 
-	p, err := aws.NewProvider(nil, ec2.NewFromConfig(cfg), map[string]string{"profile": "my-profile"})
+	p, err := aws.NewProvider(nil, ec2.NewFromConfig(*cfg), map[string]string{"profile": "my-profile"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -40,13 +36,9 @@ func TestNewProvider(t *testing.T) {
 
 func TestProviderMeta(t *testing.T) {
 	err := unusedtest.TestProviderMeta(func(meta unused.Meta) (unused.Provider, error) {
-		ctx := context.Background()
-		cfg, err := config.LoadDefaultConfig(ctx)
-		if err != nil {
-			t.Fatalf("cannot load AWS config: %v", err)
-		}
+		cfg := awsutil.NewConfig()
 
-		return aws.NewProvider(nil, ec2.NewFromConfig(cfg), meta)
+		return aws.NewProvider(nil, ec2.NewFromConfig(*cfg), meta)
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cmd/unused/internal/ui/ui.go
+++ b/cmd/unused/internal/ui/ui.go
@@ -15,6 +15,7 @@ import (
 type Filters struct {
 	Key, Value string
 	MinAge     time.Duration
+	MinUnused  time.Duration
 }
 
 type UI struct {
@@ -32,8 +33,9 @@ type UI struct {
 func (ui UI) Filter(d unused.Disk) bool {
 	minAge := ui.Filters.MinAge == 0 || time.Since(d.CreatedAt()) >= ui.Filters.MinAge
 	keyVal := ui.Filters.Key == "" || d.Meta().Matches(ui.Filters.Key, ui.Filters.Value)
+	minUnused := ui.Filters.MinUnused == 0 || time.Since(d.LastUsedAt()) >= ui.Filters.MinUnused
 
-	return minAge && keyVal
+	return minAge && keyVal && minUnused
 }
 
 func (ui UI) Run(ctx context.Context) error {

--- a/cmd/unused/internal/ui/ui.go
+++ b/cmd/unused/internal/ui/ui.go
@@ -31,6 +31,10 @@ type UI struct {
 }
 
 func (ui UI) Filter(d unused.Disk) bool {
+	if ui.Filters.MinUnused != 0 {
+		ui.Filters.MinAge = ui.Filters.MinUnused
+	}
+
 	minAge := ui.Filters.MinAge == 0 || time.Since(d.CreatedAt()) >= ui.Filters.MinAge
 	keyVal := ui.Filters.Key == "" || d.Meta().Matches(ui.Filters.Key, ui.Filters.Value)
 	minUnused := ui.Filters.MinUnused == 0 || time.Since(d.LastUsedAt()) >= ui.Filters.MinUnused

--- a/cmd/unused/internal/ui/ui_test.go
+++ b/cmd/unused/internal/ui/ui_test.go
@@ -17,7 +17,7 @@ func TestUI_Filter(t *testing.T) {
 
 		foo = unusedtest.NewDisk("foo", csp1, now.Add(-5*time.Hour), now.Add(-3*time.Hour))
 		bar = unusedtest.NewDisk("bar", csp2, now.Add(-5*time.Hour), now.Add(-10*time.Second))
-		baz = unusedtest.NewDisk("baz", csp1, now.Add(-2*time.Hour), now.Add(-1*time.Hour-30&time.Minute))
+		baz = unusedtest.NewDisk("baz", csp1, now.Add(-2*time.Hour), now.Add(-1*time.Hour-30*time.Minute))
 	)
 
 	foo.SetMeta(unused.Meta{"lorem": "ipsum"})

--- a/cmd/unused/internal/ui/ui_test.go
+++ b/cmd/unused/internal/ui/ui_test.go
@@ -15,9 +15,9 @@ func TestUI_Filter(t *testing.T) {
 
 		now = time.Now()
 
-		foo = unusedtest.NewDisk("foo", csp1, now.Add(-5*time.Hour))
-		bar = unusedtest.NewDisk("bar", csp2, now.Add(-5*time.Hour))
-		baz = unusedtest.NewDisk("baz", csp1, now.Add(-2*time.Hour))
+		foo = unusedtest.NewDisk("foo", csp1, now.Add(-5*time.Hour), now.Add(-3*time.Hour))
+		bar = unusedtest.NewDisk("bar", csp2, now.Add(-5*time.Hour), now.Add(-10*time.Second))
+		baz = unusedtest.NewDisk("baz", csp1, now.Add(-2*time.Hour), now.Add(-1*time.Hour-30&time.Minute))
 	)
 
 	foo.SetMeta(unused.Meta{"lorem": "ipsum"})
@@ -40,27 +40,32 @@ func TestUI_Filter(t *testing.T) {
 
 	tests := map[string]struct {
 		minAge   time.Duration
+		unused   time.Duration
 		key, val string
 		exp      unused.Disks
 	}{
-		"no filter": {0, "", "", disks},
+		"no filter": {0, 0, "", "", disks},
 
-		"minage": {3 * time.Hour, "", "", unused.Disks{foo, bar}},
-		"keyval": {0, "dolor", "sit amet", unused.Disks{bar}},
-		"both":   {2 * time.Hour, "dolor", "", unused.Disks{foo, baz}},
+		"minage": {3 * time.Hour, 0, "", "", unused.Disks{foo, bar}},
+		"keyval": {0, 0, "dolor", "sit amet", unused.Disks{bar}},
+		"both":   {2 * time.Hour, 0, "dolor", "", unused.Disks{foo, baz}},
 
-		"!minage": {10 * time.Hour, "", "", nil},
-		"!keyval": {0, "foo", "bar", nil},
-		"!both":   {10 * time.Hour, "foo", "bar", nil},
+		"!minage": {10 * time.Hour, 0, "", "", nil},
+		"!keyval": {0, 0, "foo", "bar", nil},
+		"!both":   {10 * time.Hour, 0, "foo", "bar", nil},
+
+		"unused":  {0, 1 * time.Hour, "", "", unused.Disks{foo, baz}},
+		"!unused": {0, 6 * time.Hour, "", "", nil},
 	}
 
 	for n, tt := range tests {
 		t.Run(n, func(t *testing.T) {
 			opts := UI{
 				Filters: Filters{
-					Key:    tt.key,
-					Value:  tt.val,
-					MinAge: tt.minAge,
+					Key:       tt.key,
+					Value:     tt.val,
+					MinAge:    tt.minAge,
+					MinUnused: tt.unused,
 				},
 			}
 

--- a/cmd/unused/internal/ui/ui_test.go
+++ b/cmd/unused/internal/ui/ui_test.go
@@ -56,6 +56,9 @@ func TestUI_Filter(t *testing.T) {
 
 		"unused":  {0, 1 * time.Hour, "", "", unused.Disks{foo, baz}},
 		"!unused": {0, 6 * time.Hour, "", "", nil},
+
+		// Special case when both MinAge and MinUnused are set
+		"both unused and minage": {3 * time.Hour, 1 * time.Hour, "", "", unused.Disks{foo, baz}},
 	}
 
 	for n, tt := range tests {

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -118,10 +118,10 @@ func main() {
 	}
 
 	if fs := out.Filters; fs.MinUnused != 0 && fs.MinAge != 0 {
-		logger.Warn("Both -min-unused and -min-age used, respecting only -min-unused",
+		logger.Warn("Both -min-unused and -min-age used, setting both to same value",
 			slog.Duration("min-unused", fs.MinUnused),
 			slog.Duration("min-age", fs.MinAge))
-		out.Filters.MinAge = 0
+		out.Filters.MinAge = fs.MinUnused
 	}
 
 	out.Providers = providers

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -67,6 +67,18 @@ func main() {
 		return nil
 	})
 
+	flag.Func("min-unused", "Minimum unused age of the disk to be listed (ex: 365d or 36h). Sets min-age to the same value", func(s string) error {
+		dur, err := internal.ParseAge(s)
+		if err != nil {
+			return err
+		}
+
+		out.Filters.MinUnused = dur
+		out.Filters.MinAge = dur
+
+		return nil
+	})
+
 	flag.Func("add-column", "Display additional column with metadata", func(c string) error {
 		out.ExtraColumns = append(out.ExtraColumns, c)
 		return nil

--- a/cmd/unused/main.go
+++ b/cmd/unused/main.go
@@ -74,7 +74,6 @@ func main() {
 		}
 
 		out.Filters.MinUnused = dur
-		out.Filters.MinAge = dur
 
 		return nil
 	})
@@ -116,6 +115,13 @@ func main() {
 		cancel()
 		fmt.Fprintln(os.Stderr, "creating providers:", err)
 		os.Exit(1)
+	}
+
+	if fs := out.Filters; fs.MinUnused != 0 && fs.MinAge != 0 {
+		logger.Warn("Both -min-unused and -min-age used, respecting only -min-unused",
+			slog.Duration("min-unused", fs.MinUnused),
+			slog.Duration("min-age", fs.MinAge))
+		out.Filters.MinAge = 0
 	}
 
 	out.Providers = providers

--- a/disks_test.go
+++ b/disks_test.go
@@ -18,9 +18,9 @@ func TestDisksSort(t *testing.T) {
 		baz = unusedtest.NewProvider("baz", nil)
 		bar = unusedtest.NewProvider("bar", nil)
 
-		gcp = unusedtest.NewDisk("ghi", foo, now.Add(-10*time.Minute))
-		aws = unusedtest.NewDisk("abc", baz, now.Add(-5*time.Minute))
-		az  = unusedtest.NewDisk("def", bar, now.Add(-2*time.Minute))
+		gcp = unusedtest.NewDisk("ghi", foo, now.Add(-10*time.Minute), now.Add(-8*time.Minute))
+		aws = unusedtest.NewDisk("abc", baz, now.Add(-5*time.Minute), now.Add(-110*time.Second))
+		az  = unusedtest.NewDisk("def", bar, now.Add(-2*time.Minute), now.Add(-1*time.Minute-30*time.Second))
 
 		disks = unused.Disks{gcp, aws, az}
 	)
@@ -81,9 +81,9 @@ func TestDisksFilter(t *testing.T) {
 		baz = unusedtest.NewProvider("baz", nil)
 		bar = unusedtest.NewProvider("bar", nil)
 
-		gcp = unusedtest.NewDisk("ghi", foo, now.Add(-10*time.Minute))
-		aws = unusedtest.NewDisk("abc", baz, now.Add(-5*time.Minute))
-		az  = unusedtest.NewDisk("def", bar, now.Add(-2*time.Minute))
+		gcp = unusedtest.NewDisk("ghi", foo, now.Add(-10*time.Minute), now.Add(-8*time.Minute))
+		aws = unusedtest.NewDisk("abc", baz, now.Add(-5*time.Minute), now.Add(-10*time.Second))
+		az  = unusedtest.NewDisk("def", bar, now.Add(-2*time.Minute), now.Add(-1*time.Minute-30*time.Second))
 
 		disks = unused.Disks{gcp, aws, az}
 	)

--- a/unusedtest/disk.go
+++ b/unusedtest/disk.go
@@ -10,17 +10,18 @@ var _ unused.Disk = Disk{}
 
 // Disk implements [unused.Disk] for testing purposes.
 type Disk struct {
-	id, name  string
-	provider  unused.Provider
-	createdAt time.Time
-	meta      unused.Meta
-	size      int
-	diskType  unused.DiskType
+	id, name   string
+	provider   unused.Provider
+	createdAt  time.Time
+	lastUsedAt time.Time
+	meta       unused.Meta
+	size       int
+	diskType   unused.DiskType
 }
 
 // NewDisk returns a new test disk.
-func NewDisk(name string, provider unused.Provider, createdAt time.Time) Disk {
-	return Disk{name, name, provider, createdAt, nil, 0, unused.Unknown}
+func NewDisk(name string, provider unused.Provider, createdAt, lastUsedAt time.Time) Disk {
+	return Disk{name, name, provider, createdAt, lastUsedAt, nil, 0, unused.Unknown}
 }
 
 func (d Disk) ID() string                { return d.name }
@@ -28,7 +29,7 @@ func (d Disk) Provider() unused.Provider { return d.provider }
 func (d Disk) Name() string              { return d.name }
 func (d Disk) CreatedAt() time.Time      { return d.createdAt }
 func (d Disk) Meta() unused.Meta         { return d.meta }
-func (d Disk) LastUsedAt() time.Time     { return d.createdAt.Add(1 * time.Minute) }
+func (d Disk) LastUsedAt() time.Time     { return d.lastUsedAt }
 func (d Disk) SizeGB() int               { return d.size }
 func (d Disk) SizeBytes() float64        { return float64(d.size) * unused.GiBbytes }
 func (d Disk) DiskType() unused.DiskType { return d.diskType }

--- a/unusedtest/disk_test.go
+++ b/unusedtest/disk_test.go
@@ -10,7 +10,7 @@ import (
 func TestDisk(t *testing.T) {
 	p := unusedtest.NewProvider("my-provider", nil)
 	createdAt := time.Now().Round(0)
-	d := unusedtest.NewDisk("my-disk", p, createdAt)
+	d := unusedtest.NewDisk("my-disk", p, createdAt, createdAt.Add(-5*time.Minute))
 
 	if exp, got := "my-disk", d.ID(); exp != got {
 		t.Errorf("expecting ID() %q, got %q", exp, got)
@@ -24,7 +24,7 @@ func TestDisk(t *testing.T) {
 	if got := d.Provider(); got != p {
 		t.Errorf("expecting Provider() %v, got %v", p, got)
 	}
-	if got, exp := d.LastUsedAt(), d.CreatedAt().Add(time.Minute); !got.Equal(exp) {
+	if got, exp := d.LastUsedAt(), d.CreatedAt().Add(-5*time.Minute); !got.Equal(exp) {
 		t.Errorf("expecting LastUsedAt() %v, got %v", exp, got)
 	}
 }

--- a/unusedtest/provider_test.go
+++ b/unusedtest/provider_test.go
@@ -59,7 +59,7 @@ func TestProviderDelete(t *testing.T) {
 		disks := make(unused.Disks, 10)
 		p := unusedtest.NewProvider("my-provider", nil, disks...)
 		for i := 0; i < cap(disks); i++ {
-			disks[i] = unusedtest.NewDisk(fmt.Sprintf("disk-%03d", i), p, now)
+			disks[i] = unusedtest.NewDisk(fmt.Sprintf("disk-%03d", i), p, now, now.Add(-5*time.Minute))
 		}
 
 		return p, disks
@@ -110,8 +110,8 @@ func TestProviderDelete(t *testing.T) {
 
 	t.Run("not found", func(t *testing.T) {
 		p, _ := setup()
-
-		if err := p.Delete(ctx, unusedtest.NewDisk("foo-bar-baz", p, time.Now())); !errors.Is(err, unusedtest.ErrDiskNotFound) {
+		now := time.Now()
+		if err := p.Delete(ctx, unusedtest.NewDisk("foo-bar-baz", p, now, now.Add(-5*time.Minute))); !errors.Is(err, unusedtest.ErrDiskNotFound) {
 			t.Fatalf("expecting error %v, got %v", unusedtest.ErrDiskNotFound, err)
 		}
 	})


### PR DESCRIPTION
Both GCP and Azure provide information on when a disk was last used/attached; AWS sadly does not. This new flag allows for filtering disks for a minimum time since the disk was last used (ex: 365d or 36h). If both -min-unused and -min-age are provided, -min-unused takes precedence.